### PR TITLE
Add lodash dependency to lib/elevate.coffee

### DIFF
--- a/build/elevate.js
+++ b/build/elevate.js
@@ -1,5 +1,7 @@
 (function() {
-  var isWindows, os, path;
+  var _, isWindows, os, path;
+
+  _ = require('lodash');
 
   os = require('os');
 

--- a/lib/elevate.coffee
+++ b/lib/elevate.coffee
@@ -1,3 +1,4 @@
+_ = require('lodash')
 os = require('os')
 path = require('path')
 


### PR DESCRIPTION
Depedency was missing and thus elevating functions threw errors.