### PR TITLE
Make "example clone" clone to a new directory

### DIFF
--- a/build/actions/examples.js
+++ b/build/actions/examples.js
@@ -1,5 +1,7 @@
 (function() {
-  var _, async, examplesData, fs, path, resin, vcs, visuals;
+  var _, async, examplesData, fs, mkdirp, path, resin, vcs, visuals;
+
+  mkdirp = require('mkdirp');
 
   async = require('async');
 
@@ -64,14 +66,21 @@
     help: 'Use this command to clone an example application to the current directory\n\nThis command outputs information about the cloning process.\nUse `--quiet` to remove that output.\n\nExample:\n\n	$ resin example clone 3',
     permission: 'user',
     action: function(params, options, done) {
-      var currentDirectory, example;
+      var currentDirectory, destination, example;
       example = examplesData[params.id - 1];
       if (example == null) {
         return done(new Error("Unknown example: " + id));
       }
       currentDirectory = process.cwd();
-      console.info("Cloning " + example.display_name + " to " + currentDirectory);
-      return vcs.clone(example.repository, currentDirectory, done);
+      destination = path.join(currentDirectory, example.name);
+      return mkdirp(destination, function(error) {
+        if (error != null) {
+          return done(error);
+        }
+        console.info("Cloning " + example.display_name + " to " + destination);
+        vcs.clone(example.repository, destination, done);
+        return done();
+      });
     }
   };
 

--- a/lib/actions/examples.coffee
+++ b/lib/actions/examples.coffee
@@ -1,3 +1,4 @@
+mkdirp = require('mkdirp')
 async = require('async')
 fs = require('fs')
 path = require('path')
@@ -86,5 +87,10 @@ exports.clone =
 			return done(new Error("Unknown example: #{id}"))
 
 		currentDirectory = process.cwd()
-		console.info("Cloning #{example.display_name} to #{currentDirectory}")
-		vcs.clone(example.repository, currentDirectory, done)
+		destination = path.join(currentDirectory, example.name)
+
+		mkdirp destination, (error) ->
+			return done(error) if error?
+			console.info("Cloning #{example.display_name} to #{destination}")
+			vcs.clone(example.repository, destination, done)
+			return done()


### PR DESCRIPTION
If you now clone Cimon, for example:

```sh
$ pwd
/Users/jviotti/Projects/resin/resin-cli

$ resin example clone 3
Cloning Cimon to /Users/jviotti/Projects/resin/resin-cli/cimon
```

A new directory is created with the example name.