### PR TITLE
Fix device await help not showing up

### DIFF
--- a/build/app.js
+++ b/build/app.js
@@ -96,13 +96,13 @@
 
   capitano.command(actions.device.init);
 
+  capitano.command(actions.device.await);
+
   capitano.command(actions.device.info);
 
   capitano.command(actions.device.remove);
 
   capitano.command(actions.device.identify);
-
-  capitano.command(actions.device.await);
 
   capitano.command(actions.drive.list);
 

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -71,10 +71,10 @@ capitano.command(actions.device.list)
 capitano.command(actions.device.supported)
 capitano.command(actions.device.rename)
 capitano.command(actions.device.init)
+capitano.command(actions.device.await)
 capitano.command(actions.device.info)
 capitano.command(actions.device.remove)
 capitano.command(actions.device.identify)
-capitano.command(actions.device.await)
 
 # ---------- Drive Module ----------
 capitano.command(actions.drive.list)


### PR DESCRIPTION
Since it was declared after device.info, doing:

  $ resin help device await

Showed the help page of the resin device command instead.