### PR TITLE
Quiet console.info if stdout is being redirected

### DIFF
--- a/build/app.js
+++ b/build/app.js
@@ -164,7 +164,7 @@
     }, function(callback) {
       var cli;
       cli = capitano.parse(process.argv);
-      if (cli.global.quiet) {
+      if (cli.global.quiet || !process.stdout.isTTY) {
         console.info = _.noop;
       }
       if (cli.global.project != null) {

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -135,7 +135,7 @@ async.waterfall([
 	(callback) ->
 		cli = capitano.parse(process.argv)
 
-		if cli.global.quiet
+		if cli.global.quiet or not process.stdout.isTTY
 			console.info = _.noop
 
 		if cli.global.project?


### PR DESCRIPTION
We use `console.info()` for feedback messages.