### PR TITLE
Open dashboardUrl instead of remoteUrl in auth login

### DIFF
--- a/build/actions/auth.js
+++ b/build/actions/auth.js
@@ -15,7 +15,7 @@
 
   visuals = require('resin-cli-visuals');
 
-  TOKEN_URL = url.resolve(settings.get('remoteUrl'), '/preferences');
+  TOKEN_URL = url.resolve(settings.get('dashboardUrl'), '/preferences');
 
   exports.login = {
     signature: 'login [token]',

--- a/lib/actions/auth.coffee
+++ b/lib/actions/auth.coffee
@@ -6,7 +6,7 @@ resin = require('resin-sdk')
 settings = require('resin-settings-client')
 visuals = require('resin-cli-visuals')
 
-TOKEN_URL = url.resolve(settings.get('remoteUrl'), '/preferences')
+TOKEN_URL = url.resolve(settings.get('dashboardUrl'), '/preferences')
 
 exports.login	=
 	signature: 'login [token]'

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "resin-cli-visuals": "^0.1.0",
     "resin-image": "^1.1.3",
     "resin-sdk": "^1.7.3",
-    "resin-settings-client": "^1.0.0",
+    "resin-settings-client": "^1.1.0",
     "resin-vcs": "^1.2.0",
     "selfupdate": "^1.1.0",
     "tmp": "^0.0.25",


### PR DESCRIPTION
When opening a browser, it currently used api.resin.io. Since the user usually login from dashboard.resin.io, and the hosts differed, the session was not shared between both of them.