### PR TITLE
Fallback to nodejs binary if node was not found

### DIFF
--- a/bin/resin
+++ b/bin/resin
@@ -1,2 +1,3 @@
-#!/usr/bin/env node
+#!/bin/sh
+':' //; exec "$(command -v nodejs || command -v node)" "$0" "$@"
 require('../build/app');


### PR DESCRIPTION
Deals with Ubuntu's non standard node binary, which is called `nodejs`.