### PR TITLE
Fix app commands order of definition. Closes #62.

### DIFF
--- a/build/app.js
+++ b/build/app.js
@@ -78,8 +78,6 @@
 
   capitano.command(actions.app.list);
 
-  capitano.command(actions.app.info);
-
   capitano.command(actions.app.remove);
 
   capitano.command(actions.app.restart);
@@ -87,6 +85,8 @@
   capitano.command(actions.app.associate);
 
   capitano.command(actions.app.init);
+
+  capitano.command(actions.app.info);
 
   capitano.command(actions.device.list);
 

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -60,11 +60,11 @@ capitano.command(actions.auth.whoami)
 # ---------- App Module ----------
 capitano.command(actions.app.create)
 capitano.command(actions.app.list)
-capitano.command(actions.app.info)
 capitano.command(actions.app.remove)
 capitano.command(actions.app.restart)
 capitano.command(actions.app.associate)
 capitano.command(actions.app.init)
+capitano.command(actions.app.info)
 
 # ---------- Device Module ----------
 capitano.command(actions.device.list)


### PR DESCRIPTION
This caused `resin help app rm` erroneusly show the help page for `resin app`.