### PR TITLE
Upgrade Capitano to v1.6.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "async": "^1.3.0",
     "bluebird": "^2.9.34",
-    "capitano": "~1.6.1",
+    "capitano": "~1.6.2",
     "coffee-script": "^1.9.3",
     "conf.js": "^0.1.1",
     "drivelist": "^1.2.2",


### PR DESCRIPTION
This release includes an improvement that helps us show a more
descriptive error message when a command requires admin privileges.