### PR TITLE
Refactor help module

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,9 @@
   "dependencies": {
     "async": "^1.3.0",
     "bluebird": "^2.9.34",
-    "capitano": "~1.6.1",
+    "capitano": "~1.7.0",
     "coffee-script": "^1.9.3",
+    "columnify": "^1.5.2",
     "html-to-text": "^1.3.1",
     "lodash": "^3.10.0",
     "mkdirp": "~0.5.0",


### PR DESCRIPTION
Main changes:

- Use the `columnify` module to display the commands instead of using
manual parsing.

- Extract logic to create a string representation from an option
signature to Capitano, and reuse here.

See https://github.com/resin-io/capitano/pull/28

Some bugs were caught and fixes during the refactoring:

- In command help, if the command didn't exist, we reused default
Capitanos command not found function which uses `process.exit(1)`. This
was changed to pass a custom error to `done()`, so the command fails
correctly when using programatically.

- General help didn't call `done()` at all, thus causing problems if
using the command programatically someday.