### PR TITLE
Use Visuals drive widget in device init

### DIFF
--- a/build/actions/device.js
+++ b/build/actions/device.js
@@ -1,5 +1,5 @@
 (function() {
-  var _, async, capitano, commandOptions, deviceConfig, drivelist, form, htmlToText, image, inject, manager, os, path, pine, registerDevice, resin, vcs, visuals;
+  var _, async, capitano, commandOptions, deviceConfig, form, htmlToText, image, inject, manager, os, path, pine, registerDevice, resin, vcs, visuals;
 
   capitano = require('capitano');
 
@@ -28,8 +28,6 @@
   deviceConfig = require('resin-device-config');
 
   form = require('resin-cli-form');
-
-  drivelist = require('drivelist');
 
   htmlToText = require('html-to-text');
 
@@ -210,26 +208,7 @@
           if (params.device != null) {
             return callback(null, params.device);
           }
-          return drivelist.list(function(error, drives) {
-            if (error != null) {
-              return callback(error);
-            }
-            return async.reject(drives, drivelist.isSystem, function(removableDrives) {
-              if (_.isEmpty(removableDrives)) {
-                return callback(new Error('No available drives'));
-              }
-              return form.ask({
-                message: 'Drive',
-                type: 'list',
-                choices: _.map(removableDrives, function(item) {
-                  return {
-                    name: item.device + " (" + item.size + ") - " + item.description,
-                    value: item.device
-                  };
-                })
-              }).nodeify(callback);
-            });
-          });
+          return visuals.drive().nodeify(callback);
         }, function(device, callback) {
           var message;
           params.device = device;

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -12,7 +12,6 @@ registerDevice = require('resin-register-device')
 pine = require('resin-pine')
 deviceConfig = require('resin-device-config')
 form = require('resin-cli-form')
-drivelist = require('drivelist')
 htmlToText = require('html-to-text')
 os = require('os')
 
@@ -289,23 +288,7 @@ exports.init =
 					return callback(new Error("Invalid application: #{options.application}"))
 
 				return callback(null, params.device) if params.device?
-				drivelist.list (error, drives) ->
-					return callback(error) if error?
-
-					async.reject drives, drivelist.isSystem, (removableDrives) ->
-
-						if _.isEmpty(removableDrives)
-							return callback(new Error('No available drives'))
-
-						form.ask
-							message: 'Drive'
-							type: 'list'
-							choices: _.map removableDrives, (item) ->
-								return {
-									name: "#{item.device} (#{item.size}) - #{item.description}"
-									value: item.device
-								}
-						.nodeify(callback)
+				visuals.drive().nodeify(callback)
 
 			(device, callback) ->
 				params.device = device

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "bluebird": "^2.9.34",
     "capitano": "~1.6.1",
     "coffee-script": "^1.9.3",
-    "drivelist": "^1.2.2",
     "html-to-text": "^1.3.1",
     "lodash": "^3.10.0",
     "mkdirp": "~0.5.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "npm": "^2.13.0",
     "open": "0.0.5",
     "resin-cli-form": "^1.1.0",
-    "resin-cli-visuals": "^1.0.0",
+    "resin-cli-visuals": "^1.1.0",
     "resin-config-inject": "^2.0.0",
     "resin-device-config": "^1.0.0",
     "resin-image": "^1.1.4",


### PR DESCRIPTION
- Upgrade Resin CLI Visuals to v1.1.0.
- Replace custom `drivelist` logic in "device init" with the new `drive`
widget.