### PR TITLE
Refactor app actions to use promises

### DIFF
--- a/build/utils/helpers.js
+++ b/build/utils/helpers.js
@@ -1,0 +1,29 @@
+(function() {
+  var Promise, form;
+
+  Promise = require('bluebird');
+
+  form = require('resin-cli-form');
+
+  exports.selectDeviceType = function() {
+    return form.ask({
+      message: 'Device Type',
+      type: 'list',
+      choices: ['Raspberry Pi', 'Raspberry Pi 2', 'BeagleBone Black']
+    });
+  };
+
+  exports.confirm = function(yesOption, message) {
+    return Promise["try"](function() {
+      if (yesOption) {
+        return true;
+      }
+      return form.ask({
+        message: message,
+        type: 'confirm',
+        "default": false
+      });
+    });
+  };
+
+}).call(this);

--- a/lib/utils/helpers.coffee
+++ b/lib/utils/helpers.coffee
@@ -1,0 +1,23 @@
+Promise = require('bluebird')
+form = require('resin-cli-form')
+
+exports.selectDeviceType = ->
+	return form.ask
+		message: 'Device Type'
+		type: 'list'
+		choices: [
+
+			# Lock to specific devices until we support
+			# the rest with device specs.
+			'Raspberry Pi'
+			'Raspberry Pi 2'
+			'BeagleBone Black'
+		]
+
+exports.confirm = (yesOption, message) ->
+	Promise.try ->
+		return true if yesOption
+		return form.ask
+			message: message
+			type: 'confirm'
+			default: false


### PR DESCRIPTION
Use promises instead of `async` internally inside the following
commands:

- app create.
- app remove.
- app associate.