### PR TITLE
Fix logs command help string indentation

### DIFF
--- a/lib/actions/logs.coffee
+++ b/lib/actions/logs.coffee
@@ -5,21 +5,21 @@ module.exports =
 	signature: 'logs <uuid>'
 	description: 'show device logs'
 	help: '''
-	      	Use this command to show logs for a specific device.
+		Use this command to show logs for a specific device.
 
-	      	By default, the command prints all log messages and exit.
+		By default, the command prints all log messages and exit.
 
-	      	To continuously stream output, and see new logs in real time, use the `--tail` option.
+		To continuously stream output, and see new logs in real time, use the `--tail` option.
 
-	      	Note that for now you need to provide the whole UUID for this command to work correctly.
+		Note that for now you need to provide the whole UUID for this command to work correctly.
 
-	      	This is due to some technical limitations that we plan to address soon.
+		This is due to some technical limitations that we plan to address soon.
 
-	      	Examples:
+		Examples:
 
-	      		$ resin logs 23c73a12e3527df55c60b9ce647640c1b7da1b32d71e6a39849ac0f00db828
-	      		$ resin logs 23c73a12e3527df55c60b9ce647640c1b7da1b32d71e6a39849ac0f00db828 --tail
-	      '''
+			$ resin logs 23c73a12e3527df55c60b9ce647640c1b7da1b32d71e6a39849ac0f00db828
+			$ resin logs 23c73a12e3527df55c60b9ce647640c1b7da1b32d71e6a39849ac0f00db828 --tail
+	'''
 	options: [
 		{
 			signature: 'tail'


### PR DESCRIPTION
For some reason it was indented a few times unnecesarily.