### PR TITLE
Force logs command to exit when not in --tail mode. Fix #14.

### DIFF
--- a/build/actions/logs.js
+++ b/build/actions/logs.js
@@ -24,7 +24,9 @@
         return console.log(line.message);
       });
       if (!options.tail) {
-        return promise.nodeify(done);
+        return promise["catch"](done)["finally"](function() {
+          return process.exit(0);
+        });
       }
       return promise.then(function() {
         return resin.logs.subscribe(params.uuid).then(function(logs) {

--- a/lib/actions/logs.coffee
+++ b/lib/actions/logs.coffee
@@ -34,7 +34,12 @@ module.exports =
 			console.log(line.message)
 
 		if not options.tail
-			return promise.nodeify(done)
+
+			# PubNub keeps the process alive after a history query.
+			# Until this is fixed, we force the process to exit.
+			# This of course prevents this command to be used programatically
+			return promise.catch(done).finally ->
+				process.exit(0)
 
 		promise.then ->
 			resin.logs.subscribe(params.uuid).then (logs) ->


### PR DESCRIPTION
PubNub keeps the process alive after a history query for some reason, so
trying to print the logs history like:

	$ resin logs <uuid>

Will result in the logs being printed correctly, but the process waiting
infinitely without ending.

The workaround consists in forcing `process.exit` to exit the process
with an error code zero.

Caveats:

- This workaround prevents this command to be used programatically.

Issue: https://github.com/resin-io/resin-cli/issues/14