### PR TITLE
Validate that email address is valid during signup. Fix #111

### DIFF
--- a/build/actions/auth.js
+++ b/build/actions/auth.js
@@ -1,5 +1,5 @@
 (function() {
-  var TOKEN_URL, _, async, form, open, resin, settings, url, visuals;
+  var TOKEN_URL, _, async, form, open, resin, settings, url, validEmail, visuals;
 
   open = require('open');
 
@@ -16,6 +16,8 @@
   form = require('resin-cli-form');
 
   visuals = require('resin-cli-visuals');
+
+  validEmail = require('valid-email');
 
   TOKEN_URL = url.resolve(settings.get('dashboardUrl'), '/preferences');
 
@@ -106,7 +108,13 @@
             {
               message: 'Email:',
               name: 'email',
-              type: 'input'
+              type: 'input',
+              validate: function(input) {
+                if (!validEmail(input)) {
+                  return 'Email is not valid';
+                }
+                return true;
+              }
             }, {
               message: 'Username:',
               name: 'username',

--- a/lib/actions/auth.coffee
+++ b/lib/actions/auth.coffee
@@ -6,6 +6,7 @@ resin = require('resin-sdk')
 settings = require('resin-settings-client')
 form = require('resin-cli-form')
 visuals = require('resin-cli-visuals')
+validEmail = require('valid-email')
 
 TOKEN_URL = url.resolve(settings.get('dashboardUrl'), '/preferences')
 
@@ -139,6 +140,11 @@ exports.signup =
 					message: 'Email:'
 					name: 'email'
 					type: 'input'
+					validate: (input) ->
+						if not validEmail(input)
+							return 'Email is not valid'
+
+						return true
 				,
 					message: 'Username:'
 					name: 'username'

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "resin-vcs": "^2.0.0",
     "selfupdate": "^1.1.0",
     "underscore.string": "^3.1.1",
-    "user-home": "^2.0.0"
+    "user-home": "^2.0.0",
+    "valid-email": "0.0.2"
   }
 }


### PR DESCRIPTION
For this we use a third party dependency from npm called `valid-email`
to avoid hardcoding and having to mantain a regular expression.