### PR TITLE
Print ssh key separately from the information table

### DIFF
--- a/build/actions/keys.js
+++ b/build/actions/keys.js
@@ -38,7 +38,8 @@
     permission: 'user',
     action: function(params, options, done) {
       return resin.models.key.get(params.id).then(function(key) {
-        return console.log(visuals.table.vertical(key, ['id', 'title', 'public_key']));
+        console.log(visuals.table.vertical(key, ['id', 'title']));
+        return console.log('\n' + key.public_key);
       }).nodeify(done);
     }
   };

--- a/lib/actions/keys.coffee
+++ b/lib/actions/keys.coffee
@@ -37,7 +37,15 @@ exports.info =
 	permission: 'user'
 	action: (params, options, done) ->
 		resin.models.key.get(params.id).then (key) ->
-			console.log visuals.table.vertical key, [ 'id', 'title', 'public_key' ]
+			console.log visuals.table.vertical key, [
+				'id'
+				'title'
+			]
+
+			# Since the public key string is long, it might
+			# wrap to lines below, causing the table layout to break.
+			# See https://github.com/resin-io/resin-cli/issues/151
+			console.log('\n' + key.public_key)
 		.nodeify(done)
 
 exports.remove =


### PR DESCRIPTION
Since the public key string is long, it might wrap to lines below,
causing the table layout to break.

A quick solutio is to print the ssh key after the table.

Fixes:

- https://github.com/resin-io/resin-cli/issues/151