### PR TITLE
Use `env_var_name` as the name property for devices env vars. Fix #120

### DIFF
--- a/build/actions/environment-variables.js
+++ b/build/actions/environment-variables.js
@@ -30,7 +30,10 @@
           if (options.application != null) {
             return resin.models.environmentVariables.getAllByApplication(options.application).nodeify(callback);
           } else if (options.device != null) {
-            return resin.models.environmentVariables.device.getAll(options.device).nodeify(callback);
+            return resin.models.environmentVariables.device.getAll(options.device).map(function(envVar) {
+              envVar.name = envVar.env_var_name;
+              return envVar;
+            }).nodeify(callback);
           } else {
             return callback(new Error('You must specify an application or device'));
           }

--- a/lib/actions/environment-variables.coffee
+++ b/lib/actions/environment-variables.coffee
@@ -40,7 +40,15 @@ exports.list =
 				if options.application?
 					resin.models.environmentVariables.getAllByApplication(options.application).nodeify(callback)
 				else if options.device?
-					resin.models.environmentVariables.device.getAll(options.device).nodeify(callback)
+					resin.models.environmentVariables.device.getAll(options.device).map (envVar) ->
+
+						# Device environment variables object contain the name
+						# as `env_var_name` instead of `name`, as the application
+						# environment variables.
+						envVar.name = envVar.env_var_name
+
+						return envVar
+					.nodeify(callback)
 				else
 					return callback(new Error('You must specify an application or device'))
 


### PR DESCRIPTION
Application environment variables contain a property called `name`,
which is found as `env_var_name` on device environment variables
instead.

This fix maps the device environment variables to assign `name` to
`env_var_name` as a workaround, until the inconsistency is fixed in the
infrastructure side.

Fixes:

- https://github.com/resin-io/resin-cli/issues/120