### PR TITLE
Fix broken device await command

### DIFF
--- a/build/actions/device.js
+++ b/build/actions/device.js
@@ -1,5 +1,7 @@
 (function() {
-  var _, async, capitano, commandOptions, deviceConfig, form, htmlToText, image, inject, manager, pine, registerDevice, resin, vcs, visuals;
+  var Promise, _, async, capitano, commandOptions, deviceConfig, form, htmlToText, image, inject, manager, pine, registerDevice, resin, vcs, visuals;
+
+  Promise = require('bluebird');
 
   capitano = require('capitano');
 
@@ -159,18 +161,17 @@
       if (options.interval == null) {
         options.interval = 3000;
       }
-      return poll = function() {
+      poll = function() {
         return resin.models.device.isOnline(params.uuid).then(function(isOnline) {
           if (isOnline) {
             console.info("Device became online: " + params.uuid);
-            return;
           } else {
             console.info("Polling device network status: " + params.uuid);
             return Promise.delay(options.interval).then(poll);
           }
-          return poll().nodeify(done);
         });
       };
+      return poll().nodeify(done);
     }
   };
 

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -1,3 +1,4 @@
+Promise = require('bluebird')
 capitano = require('capitano')
 _ = require('lodash')
 async = require('async')
@@ -221,7 +222,7 @@ exports.await =
 				else
 					console.info("Polling device network status: #{params.uuid}")
 					return Promise.delay(options.interval).then(poll)
-    poll().nodeify(done)
+		poll().nodeify(done)
 
 exports.init =
 	signature: 'device init [device]'


### PR DESCRIPTION
There were two issues that prevented this command from working
correctly:

1- `Promise.delay()` is used, but `Promise` was not imported.
2- The following line had incorrect indentation (spaces instead of
		tabs):

		poll().nodeify(done)

Therefore CoffeeScript interpreted that the line had to be executed at
the end of the `poll()` function, causing `poll()` to never be called.