### PR TITLE
Make use of `projectsDirectory` SDK setting in Quickstart

### DIFF
--- a/build/actions/wizard.js
+++ b/build/actions/wizard.js
@@ -1,5 +1,5 @@
 (function() {
-  var Promise, _, async, capitano, form, mkdirp, path, resin, userHome, visuals;
+  var Promise, _, async, capitano, form, mkdirp, resin, visuals;
 
   _ = require('lodash');
 
@@ -7,11 +7,7 @@
 
   capitano = Promise.promisifyAll(require('capitano'));
 
-  path = require('path');
-
   mkdirp = require('mkdirp');
-
-  userHome = require('user-home');
 
   visuals = require('resin-cli-visuals');
 
@@ -86,10 +82,12 @@
           return capitano.run("device " + params.uuid, callback);
         }, function(callback) {
           console.log('Your device is ready, lets start pushing some code!');
-          return form.ask({
-            message: 'Please choose a directory for your code',
-            type: 'input',
-            "default": path.join(userHome, 'ResinProjects', params.name)
+          return resin.settings.get('projectsDirectory').then(function(projectsDirectory) {
+            return form.ask({
+              message: 'Please choose a directory for your code',
+              type: 'input',
+              "default": projectsDirectory
+            });
           }).nodeify(callback);
         }, function(directoryName, callback) {
           params.directory = directoryName;

--- a/lib/actions/wizard.coffee
+++ b/lib/actions/wizard.coffee
@@ -1,9 +1,7 @@
 _ = require('lodash')
 Promise = require('bluebird')
 capitano = Promise.promisifyAll(require('capitano'))
-path = require('path')
 mkdirp = require('mkdirp')
-userHome = require('user-home')
 visuals = require('resin-cli-visuals')
 async = require('async')
 resin = require('resin-sdk')
@@ -97,12 +95,11 @@ exports.wizard =
 
 			(callback) ->
 				console.log('Your device is ready, lets start pushing some code!')
-				form.ask
-					message: 'Please choose a directory for your code'
-					type: 'input'
-
-					# TODO: Move this to resin-settings-client.
-					default: path.join(userHome, 'ResinProjects', params.name)
+				resin.settings.get('projectsDirectory').then (projectsDirectory) ->
+					form.ask
+						message: 'Please choose a directory for your code'
+						type: 'input'
+						default: projectsDirectory
 				.nodeify(callback)
 
 			(directoryName, callback) ->

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "resin-vcs": "^2.0.0",
     "selfupdate": "^1.1.0",
     "underscore.string": "^3.1.1",
-    "user-home": "^2.0.0",
     "valid-email": "0.0.2"
   }
 }


### PR DESCRIPTION
We were currently building this path ourselves, hardcoding the place of
the resin local per user directory instead of relying on the foundations
that `resin-settings-client` give us.