### PR TITLE
Add message informing the user about potential delay in system img initialization. Fix #90.

### DIFF
--- a/build/actions/device.js
+++ b/build/actions/device.js
@@ -251,6 +251,7 @@
         }, function(results, callback) {
           var bar, spinner;
           console.info('Initializing device operating system image');
+          console.info('This may take a few minutes');
           if (process.env.DEBUG) {
             console.log(results.config);
           }

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -332,6 +332,7 @@ exports.init =
 
 			(results, callback) ->
 				console.info('Initializing device operating system image')
+				console.info('This may take a few minutes')
 
 				if process.env.DEBUG
 					console.log(results.config)


### PR DESCRIPTION
[Issue #90](https://github.com/resin-io/resin-cli/issues/90)