### PR TITLE
Display msg when app/device does not have env variables. Fix #166.

### DIFF
--- a/build/actions/environment-variables.js
+++ b/build/actions/environment-variables.js
@@ -37,6 +37,9 @@
         }
       }).tap(function(environmentVariables) {
         var isSystemVariable;
+        if (_.isEmpty(environmentVariables)) {
+          throw new Error('No environment variables found');
+        }
         if (!options.verbose) {
           isSystemVariable = resin.models.environmentVariables.isSystemVariable;
           environmentVariables = _.reject(environmentVariables, isSystemVariable);

--- a/lib/actions/environment-variables.coffee
+++ b/lib/actions/environment-variables.coffee
@@ -44,6 +44,8 @@ exports.list =
 				throw new Error('You must specify an application or device')
 
 		.tap (environmentVariables) ->
+			if _.isEmpty(environmentVariables)
+				throw new Error('No environment variables found')
 			if not options.verbose
 				isSystemVariable = resin.models.environmentVariables.isSystemVariable
 				environmentVariables = _.reject(environmentVariables, isSystemVariable)


### PR DESCRIPTION
[Issue #166](https://github.com/resin-io/resin-cli/issues/166)
