### PR TITLE
Upgrade Resin CLI Form to v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "nplugm": "^3.0.0",
     "npm": "^2.13.0",
     "open": "0.0.5",
-    "resin-cli-form": "^1.2.0",
+    "resin-cli-form": "^1.2.1",
     "resin-cli-visuals": "^1.1.0",
     "resin-config-inject": "^2.0.0",
     "resin-device-config": "^1.0.0",


### PR DESCRIPTION
This version contains a fix for a bug that prevented `when` properties
from working as expected.