### PR TITLE
Add `Aborted` error message when not accepting a confirmation

### DIFF
--- a/build/actions/app.js
+++ b/build/actions/app.js
@@ -80,10 +80,7 @@
     options: [commandOptions.yes],
     permission: 'user',
     action: function(params, options, done) {
-      return helpers.confirm(option.yes, 'Are you sure you want to delete the application?').then(function(confirmed) {
-        if (!confirmed) {
-          return;
-        }
+      return helpers.confirm(options.yes, 'Are you sure you want to delete the application?').then(function() {
         return resin.models.application.remove(params.name);
       }).nodeify(done);
     }
@@ -106,10 +103,7 @@
         var message;
         message = "Are you sure you want to associate " + currentDirectory + " with " + params.name + "?";
         return helpers.confirm(options.yes, message);
-      }).then(function(confirmed) {
-        if (!confirmed) {
-          return;
-        }
+      }).then(function() {
         return resin.models.application.get(params.name).get('git_repository').then(function(gitRepository) {
           return vcs.initialize(currentDirectory).then(function() {
             return vcs.associate(currentDirectory, gitRepository);

--- a/build/actions/device.js
+++ b/build/actions/device.js
@@ -75,10 +75,7 @@
     options: [commandOptions.yes],
     permission: 'user',
     action: function(params, options, done) {
-      return helpers.confirm(options.yes, 'Are you sure you want to delete the device?').then(function(confirmed) {
-        if (!confirmed) {
-          return;
-        }
+      return helpers.confirm(options.yes, 'Are you sure you want to delete the device?').then(function() {
         return resin.models.device.remove(params.uuid);
       }).nodeify(done);
     }

--- a/build/actions/environment-variables.js
+++ b/build/actions/environment-variables.js
@@ -56,10 +56,7 @@
     options: [commandOptions.yes, commandOptions.booleanDevice],
     permission: 'user',
     action: function(params, options, done) {
-      return helpers.confirm(options.yes, 'Are you sure you want to delete the environment variable?').then(function(confirmed) {
-        if (!confirmed) {
-          return;
-        }
+      return helpers.confirm(options.yes, 'Are you sure you want to delete the environment variable?').then(function() {
         if (options.device) {
           return resin.models.environmentVariables.device.remove(params.id);
         } else {

--- a/build/actions/keys.js
+++ b/build/actions/keys.js
@@ -49,10 +49,7 @@
     options: [commandOptions.yes],
     permission: 'user',
     action: function(params, options, done) {
-      return helpers.confirm(options.yes, 'Are you sure you want to delete the key?').then(function(confirmed) {
-        if (!confirmed) {
-          return;
-        }
+      return helpers.confirm(options.yes, 'Are you sure you want to delete the key?').then(function() {
         return resin.models.key.remove(params.id);
       }).nodeify(done);
     }

--- a/build/utils/helpers.js
+++ b/build/utils/helpers.js
@@ -23,6 +23,10 @@
         type: 'confirm',
         "default": false
       });
+    }).then(function(confirmed) {
+      if (!confirmed) {
+        throw new Error('Aborted');
+      }
     });
   };
 

--- a/lib/actions/app.coffee
+++ b/lib/actions/app.coffee
@@ -125,8 +125,7 @@ exports.remove =
 	options: [ commandOptions.yes ]
 	permission: 'user'
 	action: (params, options, done) ->
-		helpers.confirm(option.yes, 'Are you sure you want to delete the application?').then (confirmed) ->
-			return if not confirmed
+		helpers.confirm(options.yes, 'Are you sure you want to delete the application?').then ->
 			resin.models.application.remove(params.name)
 		.nodeify(done)
 
@@ -157,9 +156,7 @@ exports.associate =
 		.then ->
 			message = "Are you sure you want to associate #{currentDirectory} with #{params.name}?"
 			helpers.confirm(options.yes, message)
-
-		.then (confirmed) ->
-			return if not confirmed
+		.then ->
 
 			resin.models.application.get(params.name).get('git_repository').then (gitRepository) ->
 				vcs.initialize(currentDirectory).then ->

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -105,8 +105,7 @@ exports.remove =
 	options: [ commandOptions.yes ]
 	permission: 'user'
 	action: (params, options, done) ->
-		helpers.confirm(options.yes, 'Are you sure you want to delete the device?').then (confirmed) ->
-			return if not confirmed
+		helpers.confirm(options.yes, 'Are you sure you want to delete the device?').then ->
 			resin.models.device.remove(params.uuid)
 		.nodeify(done)
 

--- a/lib/actions/environment-variables.coffee
+++ b/lib/actions/environment-variables.coffee
@@ -82,9 +82,7 @@ exports.remove =
 	]
 	permission: 'user'
 	action: (params, options, done) ->
-		helpers.confirm(options.yes, 'Are you sure you want to delete the environment variable?').then (confirmed) ->
-			return if not confirmed
-
+		helpers.confirm(options.yes, 'Are you sure you want to delete the environment variable?').then ->
 			if options.device
 				resin.models.environmentVariables.device.remove(params.id)
 			else

--- a/lib/actions/keys.coffee
+++ b/lib/actions/keys.coffee
@@ -67,8 +67,7 @@ exports.remove =
 	options: [ commandOptions.yes ]
 	permission: 'user'
 	action: (params, options, done) ->
-		helpers.confirm(options.yes, 'Are you sure you want to delete the key?').then (confirmed) ->
-			return if not confirmed
+		helpers.confirm(options.yes, 'Are you sure you want to delete the key?').then ->
 			resin.models.key.remove(params.id)
 		.nodeify(done)
 

--- a/lib/utils/helpers.coffee
+++ b/lib/utils/helpers.coffee
@@ -21,3 +21,6 @@ exports.confirm = (yesOption, message) ->
 			message: message
 			type: 'confirm'
 			default: false
+	.then (confirmed) ->
+		if not confirmed
+			throw new Error('Aborted')


### PR DESCRIPTION
This prevents a lot of duplicate code to check for confirmation status
and exit from the current action.