### PR TITLE
Don't check for available updates when running as root

### DIFF
--- a/build/utils/update.js
+++ b/build/utils/update.js
@@ -1,13 +1,17 @@
 (function() {
-  var notifier, packageJSON, updateNotifier;
+  var isRoot, notifier, packageJSON, updateNotifier;
 
   updateNotifier = require('update-notifier');
 
+  isRoot = require('is-root');
+
   packageJSON = require('../../package.json');
 
-  notifier = updateNotifier({
-    pkg: packageJSON
-  });
+  if (!isRoot()) {
+    notifier = updateNotifier({
+      pkg: packageJSON
+    });
+  }
 
   exports.hasAvailableUpdate = function() {
     return notifier != null;

--- a/lib/utils/update.coffee
+++ b/lib/utils/update.coffee
@@ -1,7 +1,12 @@
 updateNotifier = require('update-notifier')
+isRoot = require('is-root')
 packageJSON = require('../../package.json')
 
-notifier = updateNotifier(pkg: packageJSON)
+# `update-notifier` creates files to make the next
+# running time ask for updated, however this can lead
+# to ugly EPERM issues if those files are created as root.
+if not isRoot()
+	notifier = updateNotifier(pkg: packageJSON)
 
 exports.hasAvailableUpdate = ->
 	return notifier?

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "coffee-script": "^1.9.3",
     "columnify": "^1.5.2",
     "html-to-text": "^1.3.1",
+    "is-root": "^1.0.0",
     "lodash": "^3.10.0",
     "mkdirp": "~0.5.0",
     "nplugm": "^3.0.0",


### PR DESCRIPTION
`update-notifier` persist its update check results in a file, which is
then read when running again the application.

If this file gets written when the application is being run as root, we
get ugly EPERM issues.