### PR TITLE
Check token validity against the API when login

### DIFF
--- a/build/actions/auth.js
+++ b/build/actions/auth.js
@@ -41,7 +41,14 @@
             type: 'input'
           });
         });
-      }).then(resin.auth.loginWithToken).then(resin.auth.whoami).tap(function(username) {
+      }).then(resin.auth.loginWithToken).then(function(token) {
+        return resin.auth.isLoggedIn().then(function(isLoggedIn) {
+          if (isLoggedIn) {
+            return token;
+          }
+          throw new Error('Authentication failed');
+        });
+      }).then(resin.auth.whoami).tap(function(username) {
         console.info("Successfully logged in as: " + username);
         return events.send('user.login');
       }).nodeify(done);

--- a/lib/actions/auth.coffee
+++ b/lib/actions/auth.coffee
@@ -48,6 +48,10 @@ exports.login	=
 					type: 'input'
 
 		.then(resin.auth.loginWithToken)
+		.then (token) ->
+			resin.auth.isLoggedIn().then (isLoggedIn) ->
+				return token if isLoggedIn
+				throw new Error('Authentication failed')
 		.then(resin.auth.whoami)
 		.tap (username) ->
 			console.info("Successfully logged in as: #{username}")


### PR DESCRIPTION
Consider the following case:

The SDK is configured to point to staging, but the user passes a token
from production, or viceversa. Since the token is valid in a sense that
is valid JWT and contains real data, the CLI will report as a success.

The user will then get Unauthorized errors when using the API.