### PR TITLE
Add resinrc.yml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ release/build
 
 npm-shrinkwrap.json
 .resinconf
+resinrc.yml


### PR DESCRIPTION
Some modules have an use case for shipping the configuration file with
the project, however this is not the case for the CLI.