### PR TITLE
Fix Project/Solution file Appveyor issue

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,10 @@ install:
 
 build: off
 
+# to run your custom scripts instead of automatic MSBuild
+build_script:
+	- call
+
 test_script:
   - node --version
   - npm --version


### PR DESCRIPTION
Appveyor suddenly complains with:

> Specify a project or solution file. The directory does not contain a
project or solution file.

The solution is to add an empty `build_script` to omit MSBuild.