### PR TITLE
Use console.info in os download

### DIFF
--- a/build/actions/os.js
+++ b/build/actions/os.js
@@ -56,7 +56,7 @@
         output = fs.createWriteStream(options.output);
         return helpers.waitStream(stream.pipe(output))["return"](options.output);
       }).tap(function(output) {
-        return console.log("The image was downloaded to " + output);
+        return console.info("The image was downloaded to " + output);
       }).nodeify(done);
     }
   };

--- a/lib/actions/os.coffee
+++ b/lib/actions/os.coffee
@@ -48,7 +48,7 @@ exports.download =
 
 			return helpers.waitStream(stream.pipe(output)).return(options.output)
 		.tap (output) ->
-			console.log("The image was downloaded to #{output}")
+			console.info("The image was downloaded to #{output}")
 		.nodeify(done)
 
 stepHandler = (step) ->


### PR DESCRIPTION
`console.info` calls can be quieted by the `--quiet` option.