### PR TITLE
Use rimraf for deleting os temporary files

### DIFF
--- a/build/actions/device.js
+++ b/build/actions/device.js
@@ -1,5 +1,5 @@
 (function() {
-  var Promise, _, capitano, commandOptions, events, form, fs, patterns, resin, rimraf, tmp, visuals;
+  var Promise, _, capitano, commandOptions, events, form, patterns, resin, rimraf, tmp, visuals;
 
   Promise = require('bluebird');
 
@@ -14,8 +14,6 @@
   form = require('resin-cli-form');
 
   events = require('resin-cli-events');
-
-  fs = Promise.promisifyAll(require('fs'));
 
   rimraf = Promise.promisify(require('rimraf'));
 
@@ -145,14 +143,7 @@
         download = function() {
           return tmp.tmpNameAsync().then(function(temporalPath) {
             return capitano.runAsync("os download --output " + temporalPath);
-          }).disposer(function(temporalPath) {
-            return fs.statAsync(temporalPath).then(function(stat) {
-              if (stat.isDirectory()) {
-                return rimraf(temporalPath);
-              }
-              return fs.unlinkAsync(temporalPath);
-            });
-          });
+          }).disposer(_.ary(rimraf, 1));
         };
         return Promise.using(download()).then(function(temporalPath) {
           return capitano.runAsync("device register " + application.app_name).then(resin.models.device.get).tap(function(device) {

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -5,7 +5,6 @@ resin = require('resin-sdk')
 visuals = require('resin-cli-visuals')
 form = require('resin-cli-form')
 events = require('resin-cli-events')
-fs = Promise.promisifyAll(require('fs'))
 rimraf = Promise.promisify(require('rimraf'))
 patterns = require('../utils/patterns')
 tmp = Promise.promisifyAll(require('tmp'))
@@ -200,10 +199,7 @@ exports.init =
 			download = ->
 				tmp.tmpNameAsync().then (temporalPath) ->
 					capitano.runAsync("os download --output #{temporalPath}")
-				.disposer (temporalPath) ->
-					fs.statAsync(temporalPath).then (stat) ->
-						return rimraf(temporalPath) if stat.isDirectory()
-						return fs.unlinkAsync(temporalPath)
+				.disposer(_.ary(rimraf, 1))
 
 			Promise.using(download()).then (temporalPath) ->
 				capitano.runAsync("device register #{application.app_name}")


### PR DESCRIPTION
We already use `rimraf` for deleting os temporary directories, however
there are a few benefits of using it for files as well:

- Simplicity. We avoid having to check if a path is a file or directory.
- `rimraf` attempts to workaround the known Windows issues of anti
viruses not closing files. Described in more detail here: https://github.com/resin-io/resin-cli/blob/master/TROUBLESHOOTING.md#i-get-ebusy-errors-after-initializing-a-device-even-as-administrator-on-windows