### PR TITLE
Uncompress zip packages in os download

### DIFF
--- a/build/actions/os.js
+++ b/build/actions/os.js
@@ -1,5 +1,5 @@
 (function() {
-  var Promise, _, form, fs, helpers, init, manager, patterns, resin, stepHandler, umount, visuals;
+  var Promise, _, form, fs, helpers, init, manager, patterns, resin, stepHandler, umount, unzip, visuals;
 
   fs = require('fs');
 
@@ -8,6 +8,8 @@
   Promise = require('bluebird');
 
   umount = Promise.promisifyAll(require('umount'));
+
+  unzip = require('unzip2');
 
   resin = require('resin-sdk');
 
@@ -53,7 +55,13 @@
         stream.on('end', function() {
           return spinner.stop();
         });
-        output = fs.createWriteStream(options.output);
+        if (stream.mime === 'application/zip') {
+          output = unzip.Extract({
+            path: options.output
+          });
+        } else {
+          output = fs.createWriteStream(options.output);
+        }
         return helpers.waitStream(stream.pipe(output))["return"](options.output);
       }).tap(function(output) {
         return console.info("The image was downloaded to " + output);

--- a/lib/actions/os.coffee
+++ b/lib/actions/os.coffee
@@ -2,6 +2,7 @@ fs = require('fs')
 _ = require('lodash')
 Promise = require('bluebird')
 umount = Promise.promisifyAll(require('umount'))
+unzip = require('unzip2')
 resin = require('resin-sdk')
 manager = require('resin-image-manager')
 visuals = require('resin-cli-visuals')
@@ -44,7 +45,13 @@ exports.download =
 			stream.on 'end', ->
 				spinner.stop()
 
-			output = fs.createWriteStream(options.output)
+			# We completely rely on the `mime` custom property
+			# to make this decision.
+			# The actual stream should be checked instead.
+			if stream.mime is 'application/zip'
+				output = unzip.Extract(path: options.output)
+			else
+				output = fs.createWriteStream(options.output)
 
 			return helpers.waitStream(stream.pipe(output)).return(options.output)
 		.tap (output) ->

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "tmp": "0.0.28",
     "umount": "^1.1.1",
     "underscore.string": "^3.1.1",
+    "unzip2": "^0.2.5",
     "update-notifier": "^0.5.0",
     "valid-email": "0.0.2"
   }


### PR DESCRIPTION
When downloading an operating system image, if the image is a zip
package, uncompress it automatically.