### PR TITLE
Send device type correctly to getManifestBySlug

### DIFF
--- a/build/actions/os.js
+++ b/build/actions/os.js
@@ -104,7 +104,7 @@
     permission: 'user',
     action: function(params, options, done) {
       console.info('Initializing device');
-      return resin.models.device.get(params.uuid).then(resin.models.device.getManifestBySlug).then(function(manifest) {
+      return resin.models.device.get(params.uuid).get('device_type').then(resin.models.device.getManifestBySlug).then(function(manifest) {
         var ref;
         return (ref = manifest.initialization) != null ? ref.options : void 0;
       }).then(form.run).tap(function(answers) {

--- a/lib/actions/os.coffee
+++ b/lib/actions/os.coffee
@@ -108,6 +108,7 @@ exports.initialize =
 	action: (params, options, done) ->
 		console.info('Initializing device')
 		resin.models.device.get(params.uuid)
+			.get('device_type')
 			.then(resin.models.device.getManifestBySlug)
 			.then (manifest) ->
 				return manifest.initialization?.options


### PR DESCRIPTION
Currently, we we're sending the wholea device object to
`getManifestBySlug`, which ended up in an unsupported device error.