### PR TITLE
Shorten the length of await device message

### DIFF
--- a/build/utils/patterns.js
+++ b/build/utils/patterns.js
@@ -96,20 +96,20 @@
   };
 
   exports.awaitDevice = function(uuid) {
-    var poll, spinner;
-    spinner = new visuals.Spinner("Waiting for your device to come online: " + uuid);
-    poll = function() {
-      return resin.models.device.isOnline(uuid).then(function(isOnline) {
-        if (isOnline) {
-          spinner.stop();
-          console.info("Device became online: " + uuid);
-        } else {
-          spinner.start();
-          return Promise.delay(3000).then(poll);
-        }
-      });
-    };
     return resin.models.device.getName(uuid).then(function(deviceName) {
+      var poll, spinner;
+      spinner = new visuals.Spinner("Waiting for " + deviceName + " to come online");
+      poll = function() {
+        return resin.models.device.isOnline(uuid).then(function(isOnline) {
+          if (isOnline) {
+            spinner.stop();
+            console.info("Device became online: " + deviceName);
+          } else {
+            spinner.start();
+            return Promise.delay(3000).then(poll);
+          }
+        });
+      };
       console.info("Waiting for " + deviceName + " to connect to resin...");
       return poll()["return"](uuid);
     });

--- a/lib/utils/patterns.coffee
+++ b/lib/utils/patterns.coffee
@@ -62,23 +62,23 @@ exports.selectProjectDirectory = ->
 			default: projectsDirectory
 
 exports.awaitDevice = (uuid) ->
-	spinner = new visuals.Spinner("Waiting for your device to come online: #{uuid}")
-
-	poll = ->
-		resin.models.device.isOnline(uuid).then (isOnline) ->
-			if isOnline
-				spinner.stop()
-				console.info("Device became online: #{uuid}")
-				return
-			else
-
-				# Spinner implementation is smart enough to
-				# not start again if it was already started
-				spinner.start()
-
-				return Promise.delay(3000).then(poll)
-
 	resin.models.device.getName(uuid).then (deviceName) ->
+		spinner = new visuals.Spinner("Waiting for #{deviceName} to come online")
+
+		poll = ->
+			resin.models.device.isOnline(uuid).then (isOnline) ->
+				if isOnline
+					spinner.stop()
+					console.info("Device became online: #{deviceName}")
+					return
+				else
+
+					# Spinner implementation is smart enough to
+					# not start again if it was already started
+					spinner.start()
+
+					return Promise.delay(3000).then(poll)
+
 		console.info("Waiting for #{deviceName} to connect to resin...")
 		poll().return(uuid)
 


### PR DESCRIPTION
If the spinner message doesn't fit in your terminal, each spinner
position will be printed in different lines.

We mitigate this by dramatically shortenning the message.