### PR TITLE
Avoid _.ary in temporal path disposer

### DIFF
--- a/build/actions/device.js
+++ b/build/actions/device.js
@@ -147,7 +147,9 @@
         download = function() {
           return tmp.tmpNameAsync().then(function(temporalPath) {
             return capitano.runAsync("os download " + application.device_type + " --output " + temporalPath);
-          }).disposer(_.ary(rimraf, 1));
+          }).disposer(function(temporalPath) {
+            return rimraf(temporalPath);
+          });
         };
         return Promise.using(download(), function(temporalPath) {
           return capitano.runAsync("device register " + application.app_name).then(resin.models.device.get).tap(function(device) {

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -203,7 +203,8 @@ exports.init =
 			download = ->
 				tmp.tmpNameAsync().then (temporalPath) ->
 					capitano.runAsync("os download #{application.device_type} --output #{temporalPath}")
-				.disposer(_.ary(rimraf, 1))
+				.disposer (temporalPath) ->
+					return rimraf(temporalPath)
 
 			Promise.using download(), (temporalPath) ->
 				capitano.runAsync("device register #{application.app_name}")


### PR DESCRIPTION
For some reason fails with a weird Bluebird error on Windows