### PR TITLE
Add missing `yes` option to `os initialize`

### DIFF
--- a/build/actions/os.js
+++ b/build/actions/os.js
@@ -1,5 +1,5 @@
 (function() {
-  var Promise, _, form, fs, helpers, init, manager, patterns, resin, stepHandler, umount, unzip, visuals;
+  var Promise, _, commandOptions, form, fs, helpers, init, manager, patterns, resin, stepHandler, umount, unzip, visuals;
 
   fs = require('fs');
 
@@ -20,6 +20,8 @@
   form = require('resin-cli-form');
 
   init = require('resin-device-init');
+
+  commandOptions = require('./command-options');
 
   helpers = require('../utils/helpers');
 
@@ -102,6 +104,7 @@
     description: 'initialize an os image',
     help: 'Use this command to initialize a previously configured operating system image.\n\nExamples:\n\n	$ resin os initialize ../path/rpi.img \'raspberry-pi\'',
     permission: 'user',
+    options: [commandOptions.yes],
     root: true,
     action: function(params, options, done) {
       console.info('Initializing device');

--- a/lib/actions/os.coffee
+++ b/lib/actions/os.coffee
@@ -8,6 +8,7 @@ manager = require('resin-image-manager')
 visuals = require('resin-cli-visuals')
 form = require('resin-cli-form')
 init = require('resin-device-init')
+commandOptions = require('./command-options')
 helpers = require('../utils/helpers')
 patterns = require('../utils/patterns')
 
@@ -105,6 +106,7 @@ exports.initialize =
 			$ resin os initialize ../path/rpi.img 'raspberry-pi'
 	'''
 	permission: 'user'
+	options: [ commandOptions.yes ]
 	root: true
 	action: (params, options, done) ->
 		console.info('Initializing device')


### PR DESCRIPTION
This option is tried to be used within the command, but is not defined
as a formal Capitano option.