### PR TITLE
Support drive option in os initialize

### DIFF
--- a/build/actions/os.js
+++ b/build/actions/os.js
@@ -104,14 +104,27 @@
     description: 'initialize an os image',
     help: 'Use this command to initialize a previously configured operating system image.\n\nExamples:\n\n	$ resin os initialize ../path/rpi.img \'raspberry-pi\'',
     permission: 'user',
-    options: [commandOptions.yes],
+    options: [
+      commandOptions.yes, {
+        signature: 'drive',
+        description: 'drive',
+        parameter: 'drive',
+        alias: 'd'
+      }
+    ],
     root: true,
     action: function(params, options, done) {
       console.info('Initializing device');
       return resin.models.device.getManifestBySlug(params.type).then(function(manifest) {
         var ref;
         return (ref = manifest.initialization) != null ? ref.options : void 0;
-      }).then(form.run).tap(function(answers) {
+      }).then(function(questions) {
+        return form.run(questions, {
+          override: {
+            drive: options.drive
+          }
+        });
+      }).tap(function(answers) {
         var message;
         if (answers.drive == null) {
           return;

--- a/lib/actions/os.coffee
+++ b/lib/actions/os.coffee
@@ -106,14 +106,25 @@ exports.initialize =
 			$ resin os initialize ../path/rpi.img 'raspberry-pi'
 	'''
 	permission: 'user'
-	options: [ commandOptions.yes ]
+	options: [
+		commandOptions.yes
+		{
+			signature: 'drive'
+			description: 'drive'
+			parameter: 'drive'
+			alias: 'd'
+		}
+	]
 	root: true
 	action: (params, options, done) ->
 		console.info('Initializing device')
 		resin.models.device.getManifestBySlug(params.type)
 			.then (manifest) ->
 				return manifest.initialization?.options
-			.then(form.run)
+			.then (questions) ->
+				return form.run questions,
+					override:
+						drive: options.drive
 			.tap (answers) ->
 				return if not answers.drive?
 				message = "This will erase #{answers.drive}. Are you sure?"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "open": "0.0.5",
     "resin-cli-errors": "^1.0.0",
     "resin-cli-events": "^1.0.2",
-    "resin-cli-form": "^1.2.1",
+    "resin-cli-form": "^1.3.0",
     "resin-cli-visuals": "^1.2.2",
     "resin-config-inject": "^2.0.0",
     "resin-device-config": "^1.0.0",


### PR DESCRIPTION
This allows the user to bypass the drive selection dialog.

This option can be used along with `--yes` to make the command
completely non-interactive. For example:

	$ resin os initialize rpi.img 'raspberry-pi' --drive /dev/disk2 --yes