### PR TITLE
Improve the way the update notifier is shown

### DIFF
--- a/build/utils/update.js
+++ b/build/utils/update.js
@@ -21,8 +21,12 @@
     if (!exports.hasAvailableUpdate()) {
       return;
     }
-    notifier.notify();
-    return console.log('Notice that you might need administrator privileges depending on your setup');
+    notifier.notify({
+      defer: false
+    });
+    if (notifier.update != null) {
+      return console.log('Notice that you might need administrator privileges depending on your setup\n');
+    }
   };
 
 }).call(this);

--- a/lib/utils/update.coffee
+++ b/lib/utils/update.coffee
@@ -13,5 +13,6 @@ exports.hasAvailableUpdate = ->
 
 exports.notify = ->
 	return if not exports.hasAvailableUpdate()
-	notifier.notify()
-	console.log('Notice that you might need administrator privileges depending on your setup')
+	notifier.notify(defer: false)
+	if notifier.update?
+		console.log('Notice that you might need administrator privileges depending on your setup\n')


### PR DESCRIPTION
Current has the following problems:

- Our custom message gets printed even if the notifier doesn't contain
an update.

- The notifier box is deferred, therefore it's printed at the end of the
command. Since our custom message is printed at the beginning, it makes
no sense at all.