### PR TITLE
Ignore advanced configuration questions by default

### DIFF
--- a/build/utils/helpers.js
+++ b/build/utils/helpers.js
@@ -15,6 +15,12 @@
 
   chalk = require('chalk');
 
+  exports.getGroupDefaults = function(group) {
+    return _.chain(group).get('options').map(function(question) {
+      return [question.name, question["default"]];
+    }).object().value();
+  };
+
   exports.getOperatingSystem = function() {
     var platform;
     platform = os.platform();

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -556,6 +556,12 @@ Examples:
 
 	$ resin os configure ../path/rpi.img 7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9
 
+### Options
+
+#### --advanced, -v
+
+show advanced commands
+
 ## os initialize &#60;image&#62;
 
 Use this command to initialize a previously configured operating system image.

--- a/lib/actions/os.coffee
+++ b/lib/actions/os.coffee
@@ -84,13 +84,29 @@ exports.configure =
 			$ resin os configure ../path/rpi.img 7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9
 	'''
 	permission: 'user'
+	options: [
+		signature: 'advanced'
+		description: 'show advanced commands'
+		boolean: true
+		alias: 'v'
+	]
 	action: (params, options, done) ->
 		console.info('Configuring operating system image')
 		resin.models.device.get(params.uuid)
 			.get('device_type')
 			.then(resin.models.device.getManifestBySlug)
 			.get('options')
-			.then(form.run)
+			.then (questions) ->
+
+				if not options.advanced
+					advancedGroup = _.findWhere questions,
+						name: 'advanced'
+						isGroup: true
+
+					if advancedGroup?
+						override = helpers.getGroupDefaults(advancedGroup)
+
+				return form.run(questions, { override })
 			.then (answers) ->
 				init.configure(params.image, params.uuid, answers).then(stepHandler)
 		.nodeify(done)

--- a/lib/utils/helpers.coffee
+++ b/lib/utils/helpers.coffee
@@ -6,6 +6,14 @@ child_process = require('child_process')
 os = require('os')
 chalk = require('chalk')
 
+exports.getGroupDefaults = (group) ->
+	return _.chain(group)
+		.get('options')
+		.map (question) ->
+			return [ question.name, question.default ]
+		.object()
+		.value()
+
 exports.getOperatingSystem = ->
 	platform = os.platform()
 	platform = 'osx' if platform is 'darwin'


### PR DESCRIPTION
The advanced questions can be enabled by passing `--advanced` in `os
configure`.