### PR TITLE
Load device info after all other device commands

### DIFF
--- a/build/app.js
+++ b/build/app.js
@@ -66,13 +66,13 @@
 
   capitano.command(actions.device.init);
 
-  capitano.command(actions.device.info);
-
   capitano.command(actions.device.remove);
 
   capitano.command(actions.device.identify);
 
   capitano.command(actions.device.register);
+
+  capitano.command(actions.device.info);
 
   capitano.command(actions.notes.set);
 

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -45,10 +45,10 @@ capitano.command(actions.app.info)
 capitano.command(actions.device.list)
 capitano.command(actions.device.rename)
 capitano.command(actions.device.init)
-capitano.command(actions.device.info)
 capitano.command(actions.device.remove)
 capitano.command(actions.device.identify)
 capitano.command(actions.device.register)
+capitano.command(actions.device.info)
 
 # ---------- Notes Module ----------
 capitano.command(actions.notes.set)


### PR DESCRIPTION
This command obscures help pages for all device commands registered
afterwards since it's a common prefix for all of them.