### PR TITLE
Remove project directory creation in quickstart

### DIFF
--- a/build/actions/wizard.js
+++ b/build/actions/wizard.js
@@ -1,15 +1,11 @@
 (function() {
-  var Promise, capitano, form, mkdirp, patterns, resin;
+  var Promise, capitano, patterns, resin;
 
   Promise = require('bluebird');
 
   capitano = Promise.promisifyAll(require('capitano'));
 
-  mkdirp = Promise.promisify(require('mkdirp'));
-
   resin = require('resin-sdk');
-
-  form = require('resin-cli-form');
 
   patterns = require('../utils/patterns');
 
@@ -38,13 +34,8 @@
         return capitano.runAsync("device init --application " + params.name);
       }).tap(patterns.awaitDevice).then(function(uuid) {
         return capitano.runAsync("device " + uuid);
-      }).tap(function() {
-        return console.log('Your device is ready, lets start pushing some code!');
-      }).then(patterns.selectProjectDirectory).tap(mkdirp).tap(process.chdir).then(function() {
-        return capitano.runAsync("app associate " + params.name);
-      }).then(function(remoteUrl) {
-        console.log("Resin git remote added: " + remoteUrl);
-        return console.log("Please type:\n\n	$ cd " + (process.cwd()) + " && git push resin master\n\nTo push your project to resin.io.");
+      }).then(function() {
+        return console.log('Your device is ready, start pushing some code!');
       }).nodeify(done);
     }
   };

--- a/build/utils/patterns.js
+++ b/build/utils/patterns.js
@@ -86,16 +86,6 @@
     });
   };
 
-  exports.selectProjectDirectory = function() {
-    return resin.settings.get('projectsDirectory').then(function(projectsDirectory) {
-      return form.ask({
-        message: 'Please choose a directory for your code',
-        type: 'input',
-        "default": projectsDirectory
-      });
-    });
-  };
-
   exports.awaitDevice = function(uuid) {
     return resin.models.device.getName(uuid).then(function(deviceName) {
       var poll, spinner;

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -1,4 +1,3 @@
-mkdirp = require('mkdirp')
 path = require('path')
 gulp = require('gulp')
 mocha = require('gulp-mocha')

--- a/lib/actions/wizard.coffee
+++ b/lib/actions/wizard.coffee
@@ -1,8 +1,6 @@
 Promise = require('bluebird')
 capitano = Promise.promisifyAll(require('capitano'))
-mkdirp = Promise.promisify(require('mkdirp'))
 resin = require('resin-sdk')
-form = require('resin-cli-form')
 patterns = require('../utils/patterns')
 
 exports.wizard =
@@ -39,20 +37,6 @@ exports.wizard =
 		.tap(patterns.awaitDevice)
 		.then (uuid) ->
 			return capitano.runAsync("device #{uuid}")
-		.tap ->
-			console.log('Your device is ready, lets start pushing some code!')
-		.then(patterns.selectProjectDirectory)
-		.tap(mkdirp)
-		.tap(process.chdir)
 		.then ->
-			return capitano.runAsync("app associate #{params.name}")
-		.then (remoteUrl) ->
-			console.log("Resin git remote added: #{remoteUrl}")
-			console.log """
-				Please type:
-
-					$ cd #{process.cwd()} && git push resin master
-
-				To push your project to resin.io.
-			"""
+			console.log('Your device is ready, start pushing some code!')
 		.nodeify(done)

--- a/lib/utils/patterns.coffee
+++ b/lib/utils/patterns.coffee
@@ -55,13 +55,6 @@ exports.selectOrCreateApplication = ->
 			type: 'input'
 			validate: validation.validateApplicationName
 
-exports.selectProjectDirectory = ->
-	resin.settings.get('projectsDirectory').then (projectsDirectory) ->
-		return form.ask
-			message: 'Please choose a directory for your code'
-			type: 'input'
-			default: projectsDirectory
-
 exports.awaitDevice = (uuid) ->
 	resin.models.device.getName(uuid).then (deviceName) ->
 		spinner = new visuals.Spinner("Waiting for #{deviceName} to come online")

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "columnify": "^1.5.2",
     "is-root": "^1.0.0",
     "lodash": "^3.10.0",
-    "mkdirp": "~0.5.0",
     "nplugm": "^3.0.0",
     "resin-cli-errors": "^1.0.0",
     "resin-cli-events": "^1.0.2",


### PR DESCRIPTION
The last part of `quickstart` feels weird. By consensus, we remove the
part that attempts to create a project directory and leave that step to
the user.