### PR TITLE
Refer to the correct waiting stream function

### DIFF
--- a/build/utils/helpers.js
+++ b/build/utils/helpers.js
@@ -1,5 +1,5 @@
 (function() {
-  var Promise, _, capitano, chalk, child_process, os;
+  var Promise, _, capitano, chalk, child_process, os, rindle;
 
   Promise = require('bluebird');
 
@@ -10,6 +10,8 @@
   _.str = require('underscore.string');
 
   child_process = require('child_process');
+
+  rindle = require('rindle');
 
   os = require('os');
 
@@ -46,7 +48,7 @@
     spawn = child_process.spawn('sudo', command, {
       stdio: 'inherit'
     });
-    return exports.waitStream(spawn);
+    return rindle.wait(spawn);
   };
 
 }).call(this);

--- a/lib/utils/helpers.coffee
+++ b/lib/utils/helpers.coffee
@@ -3,6 +3,7 @@ capitano = Promise.promisifyAll(require('capitano'))
 _ = require('lodash')
 _.str = require('underscore.string')
 child_process = require('child_process')
+rindle = require('rindle')
 os = require('os')
 chalk = require('chalk')
 
@@ -40,4 +41,4 @@ exports.sudo = (command) ->
 	spawn = child_process.spawn 'sudo', command,
 		stdio: 'inherit'
 
-	return exports.waitStream(spawn)
+	return rindle.wait(spawn)


### PR DESCRIPTION
We recently changed to using `rindle`, however looks like we forgot
to replace this particular instance.