### PR TITLE
Clarify the need of computer password during sudo

### DIFF
--- a/build/utils/helpers.js
+++ b/build/utils/helpers.js
@@ -44,6 +44,7 @@
     if (os.platform() === 'win32') {
       return capitano.runAsync(command.join(' '));
     }
+    console.log('Type your computer password to continue');
     command = _.union(_.take(process.argv, 2), command);
     spawn = child_process.spawn('sudo', command, {
       stdio: 'inherit'

--- a/lib/utils/helpers.coffee
+++ b/lib/utils/helpers.coffee
@@ -36,6 +36,7 @@ exports.sudo = (command) ->
 	if os.platform() is 'win32'
 		return capitano.runAsync(command.join(' '))
 
+	console.log('Type your computer password to continue')
 	command = _.union(_.take(process.argv, 2), command)
 
 	spawn = child_process.spawn 'sudo', command,


### PR DESCRIPTION
Since we only prompt "Password:", it might be confusing for some users
that think they have to enter their Resin.io password instead.

Fixes: https://github.com/resin-io/resin-cli/issues/239