### PR TITLE
Show uuid in devices command

### DIFF
--- a/build/actions/device.js
+++ b/build/actions/device.js
@@ -41,7 +41,7 @@
         }
         return resin.models.device.getAll();
       }).tap(function(devices) {
-        return console.log(visuals.table.horizontal(devices, ['id', 'name', 'device_type', 'is_online', 'application_name', 'status', 'last_seen']));
+        return console.log(visuals.table.horizontal(devices, ['uuid', 'name', 'device_type', 'application_name', 'status']));
       }).nodeify(done);
     }
   };

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -39,13 +39,11 @@ exports.list =
 
 		.tap (devices) ->
 			console.log visuals.table.horizontal devices, [
-				'id'
+				'uuid'
 				'name'
 				'device_type'
-				'is_online'
 				'application_name'
 				'status'
-				'last_seen'
 			]
 		.nodeify(done)
 


### PR DESCRIPTION
The command to get information about a device, `resin device` requires a
`uuid` as a parameter. Given that we don't show uuids in `resin
devices`, the user has no way to know what uuid to pass to get extra
information.

We also remove some non very used information columns from `resin
devices` to make space for the uuid.