### PR TITLE
Clarify resin url on auth and whoami

### DIFF
--- a/build/actions/auth.js
+++ b/build/actions/auth.js
@@ -34,19 +34,22 @@
     ],
     primary: true,
     action: function(params, options, done) {
-      return form.run([
-        {
-          message: 'Email:',
-          name: 'email',
-          type: 'input',
-          validate: validation.validateEmail
-        }, {
-          message: 'Password:',
-          name: 'password',
-          type: 'password'
-        }
-      ], {
-        override: options
+      return resin.settings.get('resinUrl').then(function(resinUrl) {
+        console.log("Logging in to " + resinUrl);
+        return form.run([
+          {
+            message: 'Email:',
+            name: 'email',
+            type: 'input',
+            validate: validation.validateEmail
+          }, {
+            message: 'Password:',
+            name: 'password',
+            type: 'password'
+          }
+        ], {
+          override: options
+        });
       }).then(resin.auth.login).then(resin.auth.twoFactor.isPassed).then(function(isTwoFactorAuthPassed) {
         if (isTwoFactorAuthPassed) {
           return;
@@ -114,9 +117,10 @@
     action: function(params, options, done) {
       return Promise.props({
         username: resin.auth.whoami(),
-        email: resin.auth.getEmail()
+        email: resin.auth.getEmail(),
+        url: resin.settings.get('resinUrl')
       }).then(function(results) {
-        return console.log(visuals.table.vertical(results, ['$account information$', 'username', 'email']));
+        return console.log(visuals.table.vertical(results, ['$account information$', 'username', 'email', 'url']));
       }).nodeify(done);
     }
   };

--- a/lib/actions/auth.coffee
+++ b/lib/actions/auth.coffee
@@ -32,17 +32,21 @@ exports.login	=
 	]
 	primary: true
 	action: (params, options, done) ->
-		form.run [
-				message: 'Email:'
-				name: 'email'
-				type: 'input'
-				validate: validation.validateEmail
-			,
-				message: 'Password:'
-				name: 'password'
-				type: 'password'
-		],
-			override: options
+		resin.settings.get('resinUrl')
+		.then (resinUrl) ->
+			console.log("Logging in to #{resinUrl}")
+
+			return form.run [
+					message: 'Email:'
+					name: 'email'
+					type: 'input'
+					validate: validation.validateEmail
+				,
+					message: 'Password:'
+					name: 'password'
+					type: 'password'
+			],
+				override: options
 		.then(resin.auth.login)
 		.then(resin.auth.twoFactor.isPassed)
 		.then (isTwoFactorAuthPassed) ->
@@ -133,10 +137,12 @@ exports.whoami =
 		Promise.props
 			username: resin.auth.whoami()
 			email: resin.auth.getEmail()
+			url: resin.settings.get('resinUrl')
 		.then (results) ->
 			console.log visuals.table.vertical results, [
 				'$account information$'
 				'username'
 				'email'
+				'url'
 			]
 		.nodeify(done)


### PR DESCRIPTION
When you change the `resinUrl` config from time to time it can be
confusing to remember where you're logging in, or in which host you're
in.

Currently I have to check the configuration files/environment variables
manually or run `resin settings`.

This PR prints the detected resin url on `resin login` and `resin
whoami` so it's always clear where you are.