### PR TITLE
Simplify download output message

### DIFF
--- a/build/actions/os.js
+++ b/build/actions/os.js
@@ -68,7 +68,7 @@
         }
         return rindle.wait(stream.pipe(output))["return"](options.output);
       }).tap(function(output) {
-        return console.info("The image was downloaded to " + output);
+        return console.info('The image was downloaded successfully');
       }).nodeify(done);
     }
   };

--- a/lib/actions/os.coffee
+++ b/lib/actions/os.coffee
@@ -57,7 +57,7 @@ exports.download =
 
 			return rindle.wait(stream.pipe(output)).return(options.output)
 		.tap (output) ->
-			console.info("The image was downloaded to #{output}")
+			console.info('The image was downloaded successfully')
 		.nodeify(done)
 
 stepHandler = (step) ->


### PR DESCRIPTION
The message displayed the output of the download, which was mainly used
for debugging purposes when developing `device init` and `quickstart`.