### PR TITLE
Support for login in with token

### DIFF
--- a/build/actions/auth.js
+++ b/build/actions/auth.js
@@ -20,11 +20,24 @@
   exports.login = {
     signature: 'login',
     description: 'login to resin.io',
-    help: 'Use this command to login to your resin.io account.\n\nExamples:\n\n	$ resin login',
+    help: 'Use this command to login to your resin.io account.\n\nThis command will open your web browser and prompt you to authorize the CLI\nfrom the dashboard.\n\nIf you don\'t have access to a web browser (e.g: running in a headless server),\nyou can fetch your authentication token from the preferences page and pass\nthe token option.\n\nExamples:\n\n	$ resin login\n	$ resin login --token "..."',
+    options: [
+      {
+        signature: 'token',
+        description: 'auth token',
+        parameter: 'token',
+        alias: 't'
+      }
+    ],
     primary: true,
     action: function(params, options, done) {
-      console.info('Connecting to the web dashboard');
-      return auth.login().then(resin.auth.whoami).tap(function(username) {
+      return Promise["try"](function() {
+        if (options.token != null) {
+          return resin.auth.loginWithToken(options.token);
+        }
+        console.info('Connecting to the web dashboard');
+        return auth.login();
+      }).then(resin.auth.whoami).tap(function(username) {
         console.info("Successfully logged in as: " + username);
         return events.send('user.login');
       }).nodeify(done);

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -165,9 +165,23 @@ confirm non interactively
 
 Use this command to login to your resin.io account.
 
+This command will open your web browser and prompt you to authorize the CLI
+from the dashboard.
+
+If you don't have access to a web browser (e.g: running in a headless server),
+you can fetch your authentication token from the preferences page and pass
+the token option.
+
 Examples:
 
 	$ resin login
+	$ resin login --token "..."
+
+### Options
+
+#### --token, -t &#60;token&#62;
+
+auth token
 
 ## logout
 

--- a/lib/actions/auth.coffee
+++ b/lib/actions/auth.coffee
@@ -13,14 +13,32 @@ exports.login	=
 	help: '''
 		Use this command to login to your resin.io account.
 
+		This command will open your web browser and prompt you to authorize the CLI
+		from the dashboard.
+
+		If you don't have access to a web browser (e.g: running in a headless server),
+		you can fetch your authentication token from the preferences page and pass
+		the token option.
+
 		Examples:
 
 			$ resin login
+			$ resin login --token "..."
 	'''
+	options: [
+		signature: 'token'
+		description: 'auth token'
+		parameter: 'token'
+		alias: 't'
+	]
 	primary: true
 	action: (params, options, done) ->
-		console.info('Connecting to the web dashboard')
-		auth.login()
+		Promise.try ->
+			if options.token?
+				return resin.auth.loginWithToken(options.token)
+
+			console.info('Connecting to the web dashboard')
+			return auth.login()
 		.then(resin.auth.whoami)
 		.tap (username) ->
 			console.info("Successfully logged in as: #{username}")


### PR DESCRIPTION
This is useful in the scenario when the user is using the CLI in an
environment in which he/she doesn't have access to a web browser, like a
headless server or a Vagrant development environment.