### PR TITLE
Lazy load command actions dependencies

### DIFF
--- a/build/actions/app.js
+++ b/build/actions/app.js
@@ -1,15 +1,7 @@
 (function() {
-  var commandOptions, events, patterns, resin, visuals;
-
-  resin = require('resin-sdk');
-
-  visuals = require('resin-cli-visuals');
+  var commandOptions;
 
   commandOptions = require('./command-options');
-
-  events = require('resin-cli-events');
-
-  patterns = require('../utils/patterns');
 
   exports.create = {
     signature: 'app create <name>',
@@ -26,6 +18,10 @@
     permission: 'user',
     primary: true,
     action: function(params, options, done) {
+      var events, patterns, resin;
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
+      patterns = require('../utils/patterns');
       return resin.models.application.has(params.name).then(function(hasApplication) {
         if (hasApplication) {
           throw new Error('You already have an application with that name!');
@@ -50,6 +46,9 @@
     permission: 'user',
     primary: true,
     action: function(params, options, done) {
+      var resin, visuals;
+      resin = require('resin-sdk');
+      visuals = require('resin-cli-visuals');
       return resin.models.application.getAll().then(function(applications) {
         return console.log(visuals.table.horizontal(applications, ['id', 'app_name', 'device_type', 'online_devices', 'devices_length']));
       }).nodeify(done);
@@ -63,6 +62,10 @@
     permission: 'user',
     primary: true,
     action: function(params, options, done) {
+      var events, resin, visuals;
+      resin = require('resin-sdk');
+      visuals = require('resin-cli-visuals');
+      events = require('resin-cli-events');
       return resin.models.application.get(params.name).then(function(application) {
         console.log(visuals.table.vertical(application, ["$" + application.app_name + "$", 'id', 'device_type', 'git_repository', 'commit']));
         return events.send('application.open', {
@@ -78,6 +81,8 @@
     help: 'Use this command to restart all devices that belongs to a certain application.\n\nExamples:\n\n	$ resin app restart MyApp',
     permission: 'user',
     action: function(params, options, done) {
+      var resin;
+      resin = require('resin-sdk');
       return resin.models.application.restart(params.name).nodeify(done);
     }
   };
@@ -89,6 +94,10 @@
     options: [commandOptions.yes],
     permission: 'user',
     action: function(params, options, done) {
+      var events, patterns, resin;
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
+      patterns = require('../utils/patterns');
       return patterns.confirm(options.yes, 'Are you sure you want to delete the application?').then(function() {
         return resin.models.application.remove(params.name);
       }).tap(function() {

--- a/build/actions/auth.js
+++ b/build/actions/auth.js
@@ -1,22 +1,4 @@
 (function() {
-  var Promise, _, auth, events, form, resin, validation, visuals;
-
-  Promise = require('bluebird');
-
-  _ = require('lodash');
-
-  resin = require('resin-sdk');
-
-  form = require('resin-cli-form');
-
-  visuals = require('resin-cli-visuals');
-
-  events = require('resin-cli-events');
-
-  auth = require('resin-cli-auth');
-
-  validation = require('../utils/validation');
-
   exports.login = {
     signature: 'login',
     description: 'login to resin.io',
@@ -31,6 +13,11 @@
     ],
     primary: true,
     action: function(params, options, done) {
+      var Promise, auth, events, resin;
+      Promise = require('bluebird');
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
+      auth = require('resin-cli-auth');
       return Promise["try"](function() {
         if (options.token != null) {
           return resin.auth.loginWithToken(options.token);
@@ -50,6 +37,9 @@
     help: 'Use this command to logout from your resin.io account.o\n\nExamples:\n\n	$ resin logout',
     permission: 'user',
     action: function(params, options, done) {
+      var events, resin;
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
       return resin.auth.logout().then(function() {
         return events.send('user.logout');
       }).nodeify(done);
@@ -61,6 +51,11 @@
     description: 'signup to resin.io',
     help: 'Use this command to signup for a resin.io account.\n\nIf signup is successful, you\'ll be logged in to your new user automatically.\n\nExamples:\n\n	$ resin signup\n	Email: me@mycompany.com\n	Username: johndoe\n	Password: ***********\n\n	$ resin whoami\n	johndoe',
     action: function(params, options, done) {
+      var events, form, resin, validation;
+      resin = require('resin-sdk');
+      form = require('resin-cli-form');
+      events = require('resin-cli-events');
+      validation = require('../utils/validation');
       return form.run([
         {
           message: 'Email:',
@@ -89,6 +84,10 @@
     help: 'Use this command to find out the current logged in username and email address.\n\nExamples:\n\n	$ resin whoami',
     permission: 'user',
     action: function(params, options, done) {
+      var Promise, resin, visuals;
+      Promise = require('bluebird');
+      resin = require('resin-sdk');
+      visuals = require('resin-cli-visuals');
       return Promise.props({
         username: resin.auth.whoami(),
         email: resin.auth.getEmail(),

--- a/build/actions/config.js
+++ b/build/actions/config.js
@@ -1,20 +1,4 @@
 (function() {
-  var Promise, _, capitano, config, prettyjson, umount, visuals;
-
-  _ = require('lodash');
-
-  Promise = require('bluebird');
-
-  capitano = Promise.promisifyAll(require('capitano'));
-
-  umount = Promise.promisifyAll(require('umount'));
-
-  visuals = require('resin-cli-visuals');
-
-  config = require('resin-config-json');
-
-  prettyjson = require('prettyjson');
-
   exports.read = {
     signature: 'config read',
     description: 'read a device configuration',
@@ -36,6 +20,12 @@
     permission: 'user',
     root: true,
     action: function(params, options, done) {
+      var Promise, config, prettyjson, umount, visuals;
+      Promise = require('bluebird');
+      config = require('resin-config-json');
+      visuals = require('resin-cli-visuals');
+      umount = Promise.promisifyAll(require('umount'));
+      prettyjson = require('prettyjson');
       return Promise["try"](function() {
         return options.drive || visuals.drive('Select the device drive');
       }).tap(umount.umountAsync).then(function(drive) {
@@ -67,6 +57,12 @@
     permission: 'user',
     root: true,
     action: function(params, options, done) {
+      var Promise, _, config, umount, visuals;
+      Promise = require('bluebird');
+      _ = require('lodash');
+      config = require('resin-config-json');
+      visuals = require('resin-cli-visuals');
+      umount = Promise.promisifyAll(require('umount'));
       return Promise["try"](function() {
         return options.drive || visuals.drive('Select the device drive');
       }).tap(umount.umountAsync).then(function(drive) {
@@ -111,6 +107,12 @@
     permission: 'user',
     root: true,
     action: function(params, options, done) {
+      var Promise, capitano, config, umount, visuals;
+      Promise = require('bluebird');
+      config = require('resin-config-json');
+      visuals = require('resin-cli-visuals');
+      capitano = Promise.promisifyAll(require('capitano'));
+      umount = Promise.promisifyAll(require('umount'));
       return Promise["try"](function() {
         return options.drive || visuals.drive('Select the device drive');
       }).tap(umount.umountAsync).then(function(drive) {

--- a/build/actions/device.js
+++ b/build/actions/device.js
@@ -1,29 +1,5 @@
 (function() {
-  var Promise, _, capitano, commandOptions, events, form, helpers, patterns, resin, rimraf, tmp, visuals;
-
-  Promise = require('bluebird');
-
-  capitano = Promise.promisifyAll(require('capitano'));
-
-  _ = require('lodash');
-
-  resin = require('resin-sdk');
-
-  visuals = require('resin-cli-visuals');
-
-  form = require('resin-cli-form');
-
-  events = require('resin-cli-events');
-
-  rimraf = Promise.promisify(require('rimraf'));
-
-  patterns = require('../utils/patterns');
-
-  helpers = require('../utils/helpers');
-
-  tmp = Promise.promisifyAll(require('tmp'));
-
-  tmp.setGracefulCleanup();
+  var commandOptions;
 
   commandOptions = require('./command-options');
 
@@ -35,6 +11,10 @@
     permission: 'user',
     primary: true,
     action: function(params, options, done) {
+      var Promise, resin, visuals;
+      Promise = require('bluebird');
+      resin = require('resin-sdk');
+      visuals = require('resin-cli-visuals');
       return Promise["try"](function() {
         if (options.application != null) {
           return resin.models.device.getAllByApplication(options.application);
@@ -53,6 +33,10 @@
     permission: 'user',
     primary: true,
     action: function(params, options, done) {
+      var events, resin, visuals;
+      resin = require('resin-sdk');
+      visuals = require('resin-cli-visuals');
+      events = require('resin-cli-events');
       return resin.models.device.get(params.uuid).then(function(device) {
         if (device.last_seen == null) {
           device.last_seen = 'Not seen';
@@ -79,6 +63,9 @@
       }
     ],
     action: function(params, options, done) {
+      var Promise, resin;
+      Promise = require('bluebird');
+      resin = require('resin-sdk');
       return resin.models.application.get(params.application).then(function(application) {
         return Promise["try"](function() {
           return options.uuid || resin.models.device.generateUUID();
@@ -97,6 +84,10 @@
     options: [commandOptions.yes],
     permission: 'user',
     action: function(params, options, done) {
+      var events, patterns, resin;
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
+      patterns = require('../utils/patterns');
       return patterns.confirm(options.yes, 'Are you sure you want to delete the device?').then(function() {
         return resin.models.device.remove(params.uuid);
       }).tap(function() {
@@ -113,6 +104,8 @@
     help: 'Use this command to identify a device.\n\nIn the Raspberry Pi, the ACT led is blinked several times.\n\nExamples:\n\n	$ resin device identify 23c73a12e3527df55c60b9ce647640c1b7da1b32d71e6a39849ac0f00db828',
     permission: 'user',
     action: function(params, options, done) {
+      var resin;
+      resin = require('resin-sdk');
       return resin.models.device.identify(params.uuid).nodeify(done);
     }
   };
@@ -123,6 +116,12 @@
     help: 'Use this command to rename a device.\n\nIf you omit the name, you\'ll get asked for it interactively.\n\nExamples:\n\n	$ resin device rename 7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9 MyPi\n	$ resin device rename 7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9',
     permission: 'user',
     action: function(params, options, done) {
+      var Promise, _, events, form, resin;
+      Promise = require('bluebird');
+      _ = require('lodash');
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
+      form = require('resin-cli-form');
       return Promise["try"](function() {
         if (!_.isEmpty(params.newName)) {
           return params.newName;
@@ -146,6 +145,10 @@
     permission: 'user',
     options: [commandOptions.optionalApplication],
     action: function(params, options, done) {
+      var _, patterns, resin;
+      resin = require('resin-sdk');
+      _ = require('lodash');
+      patterns = require('../utils/patterns');
       return resin.models.device.get(params.uuid).then(function(device) {
         return options.application || patterns.selectApplication(function(application) {
           return _.all([application.device_type === device.device_type, device.application_name !== application.app_name]);
@@ -173,6 +176,15 @@
     permission: 'user',
     primary: true,
     action: function(params, options, done) {
+      var Promise, capitano, helpers, patterns, resin, rimraf, tmp;
+      Promise = require('bluebird');
+      capitano = Promise.promisifyAll(require('capitano'));
+      rimraf = Promise.promisify(require('rimraf'));
+      tmp = Promise.promisifyAll(require('tmp'));
+      tmp.setGracefulCleanup();
+      resin = require('resin-sdk');
+      helpers = require('../utils/helpers');
+      patterns = require('../utils/patterns');
       return Promise["try"](function() {
         if (options.application != null) {
           return options.application;

--- a/build/actions/environment-variables.js
+++ b/build/actions/environment-variables.js
@@ -1,19 +1,7 @@
 (function() {
-  var Promise, _, commandOptions, events, patterns, resin, visuals;
-
-  Promise = require('bluebird');
-
-  _ = require('lodash');
-
-  resin = require('resin-sdk');
-
-  visuals = require('resin-cli-visuals');
-
-  events = require('resin-cli-events');
+  var commandOptions;
 
   commandOptions = require('./command-options');
-
-  patterns = require('../utils/patterns');
 
   exports.list = {
     signature: 'envs',
@@ -29,6 +17,11 @@
     ],
     permission: 'user',
     action: function(params, options, done) {
+      var Promise, _, resin, visuals;
+      Promise = require('bluebird');
+      _ = require('lodash');
+      resin = require('resin-sdk');
+      visuals = require('resin-cli-visuals');
       return Promise["try"](function() {
         if (options.application != null) {
           return resin.models.environmentVariables.getAllByApplication(options.application);
@@ -58,6 +51,10 @@
     options: [commandOptions.yes, commandOptions.booleanDevice],
     permission: 'user',
     action: function(params, options, done) {
+      var events, patterns, resin;
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
+      patterns = require('../utils/patterns');
       return patterns.confirm(options.yes, 'Are you sure you want to delete the environment variable?').then(function() {
         if (options.device) {
           resin.models.environmentVariables.device.remove(params.id);
@@ -81,6 +78,10 @@
     options: [commandOptions.optionalApplication, commandOptions.optionalDevice],
     permission: 'user',
     action: function(params, options, done) {
+      var Promise, events, resin;
+      Promise = require('bluebird');
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
       return Promise["try"](function() {
         if (params.value == null) {
           params.value = process.env[params.key];
@@ -118,6 +119,10 @@
     permission: 'user',
     options: [commandOptions.booleanDevice],
     action: function(params, options, done) {
+      var Promise, events, resin;
+      Promise = require('bluebird');
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
       return Promise["try"](function() {
         if (options.device) {
           return resin.models.environmentVariables.device.update(params.id, params.value).then(function() {

--- a/build/actions/info.js
+++ b/build/actions/info.js
@@ -1,13 +1,11 @@
 (function() {
-  var packageJSON;
-
-  packageJSON = require('../../package.json');
-
   exports.version = {
     signature: 'version',
     description: 'output the version number',
     help: 'Display the Resin CLI version.',
     action: function(params, options, done) {
+      var packageJSON;
+      packageJSON = require('../../package.json');
       console.log(packageJSON.version);
       return done();
     }

--- a/build/actions/keys.js
+++ b/build/actions/keys.js
@@ -1,23 +1,7 @@
 (function() {
-  var Promise, _, capitano, commandOptions, events, fs, patterns, resin, visuals;
-
-  Promise = require('bluebird');
-
-  fs = Promise.promisifyAll(require('fs'));
-
-  _ = require('lodash');
-
-  resin = require('resin-sdk');
-
-  capitano = require('capitano');
-
-  visuals = require('resin-cli-visuals');
-
-  events = require('resin-cli-events');
+  var commandOptions;
 
   commandOptions = require('./command-options');
-
-  patterns = require('../utils/patterns');
 
   exports.list = {
     signature: 'keys',
@@ -25,6 +9,9 @@
     help: 'Use this command to list all your SSH keys.\n\nExamples:\n\n	$ resin keys',
     permission: 'user',
     action: function(params, options, done) {
+      var resin, visuals;
+      resin = require('resin-sdk');
+      visuals = require('resin-cli-visuals');
       return resin.models.key.getAll().then(function(keys) {
         return console.log(visuals.table.horizontal(keys, ['id', 'title']));
       }).nodeify(done);
@@ -37,6 +24,9 @@
     help: 'Use this command to show information about a single SSH key.\n\nExamples:\n\n	$ resin key 17',
     permission: 'user',
     action: function(params, options, done) {
+      var resin, visuals;
+      resin = require('resin-sdk');
+      visuals = require('resin-cli-visuals');
       return resin.models.key.get(params.id).then(function(key) {
         console.log(visuals.table.vertical(key, ['id', 'title']));
         return console.log('\n' + key.public_key);
@@ -51,6 +41,10 @@
     options: [commandOptions.yes],
     permission: 'user',
     action: function(params, options, done) {
+      var events, patterns, resin;
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
+      patterns = require('../utils/patterns');
       return patterns.confirm(options.yes, 'Are you sure you want to delete the key?').then(function() {
         return resin.models.key.remove(params.id);
       }).tap(function() {
@@ -67,6 +61,13 @@
     help: 'Use this command to associate a new SSH key with your account.\n\nIf `path` is omitted, the command will attempt\nto read the SSH key from stdin.\n\nExamples:\n\n	$ resin key add Main ~/.ssh/id_rsa.pub\n	$ cat ~/.ssh/id_rsa.pub | resin key add Main',
     permission: 'user',
     action: function(params, options, done) {
+      var Promise, _, capitano, events, fs, resin;
+      _ = require('lodash');
+      Promise = require('bluebird');
+      fs = Promise.promisifyAll(require('fs'));
+      capitano = require('capitano');
+      resin = require('resin-sdk');
+      events = require('resin-cli-events');
       return Promise["try"](function() {
         if (params.path != null) {
           return fs.readFileAsync(params.path, {

--- a/build/actions/logs.js
+++ b/build/actions/logs.js
@@ -1,10 +1,4 @@
 (function() {
-  var _, resin;
-
-  _ = require('lodash');
-
-  resin = require('resin-sdk');
-
   module.exports = {
     signature: 'logs <uuid>',
     description: 'show device logs',
@@ -20,7 +14,9 @@
     permission: 'user',
     primary: true,
     action: function(params, options, done) {
-      var promise;
+      var _, promise, resin;
+      _ = require('lodash');
+      resin = require('resin-sdk');
       promise = resin.logs.history(params.uuid).each(function(line) {
         return console.log(line.message);
       });

--- a/build/actions/notes.js
+++ b/build/actions/notes.js
@@ -1,12 +1,4 @@
 (function() {
-  var Promise, _, resin;
-
-  Promise = require('bluebird');
-
-  _ = require('lodash');
-
-  resin = require('resin-sdk');
-
   exports.set = {
     signature: 'note <|note>',
     description: 'set a device note',
@@ -22,6 +14,10 @@
     ],
     permission: 'user',
     action: function(params, options, done) {
+      var Promise, _, resin;
+      Promise = require('bluebird');
+      _ = require('lodash');
+      resin = require('resin-sdk');
       return Promise["try"](function() {
         if (_.isEmpty(params.note)) {
           throw new Error('Missing note content');

--- a/build/actions/os.js
+++ b/build/actions/os.js
@@ -1,33 +1,7 @@
 (function() {
-  var Promise, _, commandOptions, form, fs, helpers, init, manager, patterns, resin, rindle, stepHandler, umount, unzip, visuals;
-
-  fs = require('fs');
-
-  _ = require('lodash');
-
-  Promise = require('bluebird');
-
-  umount = Promise.promisifyAll(require('umount'));
-
-  unzip = require('unzip2');
-
-  rindle = require('rindle');
-
-  resin = require('resin-sdk');
-
-  manager = require('resin-image-manager');
-
-  visuals = require('resin-cli-visuals');
-
-  form = require('resin-cli-form');
-
-  init = require('resin-device-init');
+  var commandOptions, stepHandler;
 
   commandOptions = require('./command-options');
-
-  helpers = require('../utils/helpers');
-
-  patterns = require('../utils/patterns');
 
   exports.download = {
     signature: 'os download <type>',
@@ -44,6 +18,12 @@
       }
     ],
     action: function(params, options, done) {
+      var fs, manager, rindle, unzip, visuals;
+      unzip = require('unzip2');
+      fs = require('fs');
+      rindle = require('rindle');
+      manager = require('resin-image-manager');
+      visuals = require('resin-cli-visuals');
       console.info("Getting device operating system for " + params.type);
       return manager.get(params.type).then(function(stream) {
         var bar, output, spinner;
@@ -74,7 +54,11 @@
   };
 
   stepHandler = function(step) {
-    var bar;
+    var _, bar, helpers, rindle, visuals;
+    _ = require('lodash');
+    rindle = require('rindle');
+    visuals = require('resin-cli-visuals');
+    helpers = require('../utils/helpers');
     step.on('stdout', _.bind(process.stdout.write, process.stdout));
     step.on('stderr', _.bind(process.stderr.write, process.stderr));
     step.on('state', function(state) {
@@ -102,6 +86,12 @@
       }
     ],
     action: function(params, options, done) {
+      var _, form, helpers, init, resin;
+      _ = require('lodash');
+      resin = require('resin-sdk');
+      form = require('resin-cli-form');
+      init = require('resin-device-init');
+      helpers = require('../utils/helpers');
       console.info('Configuring operating system image');
       return resin.models.device.get(params.uuid).get('device_type').then(resin.models.device.getManifestBySlug).get('options').then(function(questions) {
         var advancedGroup, override;
@@ -144,6 +134,13 @@
     ],
     root: true,
     action: function(params, options, done) {
+      var Promise, form, init, patterns, resin, umount;
+      Promise = require('bluebird');
+      umount = Promise.promisifyAll(require('umount'));
+      resin = require('resin-sdk');
+      form = require('resin-cli-form');
+      init = require('resin-device-init');
+      patterns = require('../utils/patterns');
       console.info('Initializing device');
       return resin.models.device.getManifestBySlug(options.type).then(function(manifest) {
         var ref;

--- a/build/actions/settings.js
+++ b/build/actions/settings.js
@@ -1,15 +1,12 @@
 (function() {
-  var prettyjson, resin;
-
-  resin = require('resin-sdk');
-
-  prettyjson = require('prettyjson');
-
   exports.list = {
     signature: 'settings',
     description: 'print current settings',
     help: 'Use this command to display detected settings\n\nExamples:\n\n	$ resin settings',
     action: function(params, options, done) {
+      var prettyjson, resin;
+      resin = require('resin-sdk');
+      prettyjson = require('prettyjson');
       return resin.settings.getAll().then(prettyjson.render).then(console.log).nodeify(done);
     }
   };

--- a/build/actions/wizard.js
+++ b/build/actions/wizard.js
@@ -1,14 +1,4 @@
 (function() {
-  var Promise, capitano, patterns, resin;
-
-  Promise = require('bluebird');
-
-  capitano = Promise.promisifyAll(require('capitano'));
-
-  resin = require('resin-sdk');
-
-  patterns = require('../utils/patterns');
-
   exports.wizard = {
     signature: 'quickstart [name]',
     description: 'getting started with resin.io',
@@ -16,6 +6,11 @@
     permission: 'user',
     primary: true,
     action: function(params, options, done) {
+      var Promise, capitano, patterns, resin;
+      Promise = require('bluebird');
+      capitano = Promise.promisifyAll(require('capitano'));
+      resin = require('resin-sdk');
+      patterns = require('../utils/patterns');
       return Promise["try"](function() {
         if (params.name != null) {
           return;

--- a/lib/actions/app.coffee
+++ b/lib/actions/app.coffee
@@ -1,8 +1,4 @@
-resin = require('resin-sdk')
-visuals = require('resin-cli-visuals')
 commandOptions = require('./command-options')
-events = require('resin-cli-events')
-patterns = require('../utils/patterns')
 
 exports.create =
 	signature: 'app create <name>'
@@ -33,6 +29,9 @@ exports.create =
 	permission: 'user'
 	primary: true
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+		patterns = require('../utils/patterns')
 
 		# Validate the the application name is available
 		# before asking the device type.
@@ -66,6 +65,9 @@ exports.list =
 	permission: 'user'
 	primary: true
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		visuals = require('resin-cli-visuals')
+
 		resin.models.application.getAll().then (applications) ->
 			console.log visuals.table.horizontal applications, [
 				'id'
@@ -89,6 +91,10 @@ exports.info =
 	permission: 'user'
 	primary: true
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		visuals = require('resin-cli-visuals')
+		events = require('resin-cli-events')
+
 		resin.models.application.get(params.name).then (application) ->
 			console.log visuals.table.vertical application, [
 				"$#{application.app_name}$"
@@ -112,6 +118,7 @@ exports.restart =
 	'''
 	permission: 'user'
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
 		resin.models.application.restart(params.name).nodeify(done)
 
 exports.remove =
@@ -131,6 +138,10 @@ exports.remove =
 	options: [ commandOptions.yes ]
 	permission: 'user'
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+		patterns = require('../utils/patterns')
+
 		patterns.confirm(options.yes, 'Are you sure you want to delete the application?').then ->
 			resin.models.application.remove(params.name)
 		.tap ->

--- a/lib/actions/auth.coffee
+++ b/lib/actions/auth.coffee
@@ -1,12 +1,3 @@
-Promise = require('bluebird')
-_ = require('lodash')
-resin = require('resin-sdk')
-form = require('resin-cli-form')
-visuals = require('resin-cli-visuals')
-events = require('resin-cli-events')
-auth = require('resin-cli-auth')
-validation = require('../utils/validation')
-
 exports.login	=
 	signature: 'login'
 	description: 'login to resin.io'
@@ -33,6 +24,11 @@ exports.login	=
 	]
 	primary: true
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+		auth = require('resin-cli-auth')
+
 		Promise.try ->
 			if options.token?
 				return resin.auth.loginWithToken(options.token)
@@ -57,6 +53,9 @@ exports.logout =
 	'''
 	permission: 'user'
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+
 		resin.auth.logout().then ->
 			events.send('user.logout')
 		.nodeify(done)
@@ -80,6 +79,11 @@ exports.signup =
 			johndoe
 	'''
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		form = require('resin-cli-form')
+		events = require('resin-cli-events')
+		validation = require('../utils/validation')
+
 		form.run [
 			message: 'Email:'
 			name: 'email'
@@ -114,6 +118,10 @@ exports.whoami =
 	'''
 	permission: 'user'
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		resin = require('resin-sdk')
+		visuals = require('resin-cli-visuals')
+
 		Promise.props
 			username: resin.auth.whoami()
 			email: resin.auth.getEmail()

--- a/lib/actions/config.coffee
+++ b/lib/actions/config.coffee
@@ -1,11 +1,3 @@
-_ = require('lodash')
-Promise = require('bluebird')
-capitano = Promise.promisifyAll(require('capitano'))
-umount = Promise.promisifyAll(require('umount'))
-visuals = require('resin-cli-visuals')
-config = require('resin-config-json')
-prettyjson = require('prettyjson')
-
 exports.read =
 	signature: 'config read'
 	description: 'read a device configuration'
@@ -35,6 +27,12 @@ exports.read =
 	permission: 'user'
 	root: true
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		config = require('resin-config-json')
+		visuals = require('resin-cli-visuals')
+		umount = Promise.promisifyAll(require('umount'))
+		prettyjson = require('prettyjson')
+
 		Promise.try ->
 			return options.drive or visuals.drive('Select the device drive')
 		.tap(umount.umountAsync)
@@ -74,6 +72,12 @@ exports.write =
 	permission: 'user'
 	root: true
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		_ = require('lodash')
+		config = require('resin-config-json')
+		visuals = require('resin-cli-visuals')
+		umount = Promise.promisifyAll(require('umount'))
+
 		Promise.try ->
 			return options.drive or visuals.drive('Select the device drive')
 		.tap(umount.umountAsync)
@@ -126,6 +130,12 @@ exports.reconfigure =
 	permission: 'user'
 	root: true
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		config = require('resin-config-json')
+		visuals = require('resin-cli-visuals')
+		capitano = Promise.promisifyAll(require('capitano'))
+		umount = Promise.promisifyAll(require('umount'))
+
 		Promise.try ->
 			return options.drive or visuals.drive('Select the device drive')
 		.tap(umount.umountAsync)

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -1,16 +1,3 @@
-Promise = require('bluebird')
-capitano = Promise.promisifyAll(require('capitano'))
-_ = require('lodash')
-resin = require('resin-sdk')
-visuals = require('resin-cli-visuals')
-form = require('resin-cli-form')
-events = require('resin-cli-events')
-rimraf = Promise.promisify(require('rimraf'))
-patterns = require('../utils/patterns')
-helpers = require('../utils/helpers')
-tmp = Promise.promisifyAll(require('tmp'))
-tmp.setGracefulCleanup()
-
 commandOptions = require('./command-options')
 
 exports.list =
@@ -32,6 +19,10 @@ exports.list =
 	permission: 'user'
 	primary: true
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		resin = require('resin-sdk')
+		visuals = require('resin-cli-visuals')
+
 		Promise.try ->
 			if options.application?
 				return resin.models.device.getAllByApplication(options.application)
@@ -61,6 +52,10 @@ exports.info =
 	permission: 'user'
 	primary: true
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		visuals = require('resin-cli-visuals')
+		events = require('resin-cli-events')
+
 		resin.models.device.get(params.uuid).then (device) ->
 
 			# TODO: We should outsource this logic and probably
@@ -104,6 +99,9 @@ exports.register =
 		alias: 'u'
 	]
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		resin = require('resin-sdk')
+
 		resin.models.application.get(params.application).then (application) ->
 
 			Promise.try ->
@@ -131,6 +129,10 @@ exports.remove =
 	options: [ commandOptions.yes ]
 	permission: 'user'
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+		patterns = require('../utils/patterns')
+
 		patterns.confirm(options.yes, 'Are you sure you want to delete the device?').then ->
 			resin.models.device.remove(params.uuid)
 		.tap ->
@@ -151,6 +153,7 @@ exports.identify =
 	'''
 	permission: 'user'
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
 		resin.models.device.identify(params.uuid).nodeify(done)
 
 exports.rename =
@@ -168,6 +171,12 @@ exports.rename =
 	'''
 	permission: 'user'
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		_ = require('lodash')
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+		form = require('resin-cli-form')
+
 		Promise.try ->
 			return params.newName if not _.isEmpty(params.newName)
 
@@ -196,6 +205,10 @@ exports.move =
 	permission: 'user'
 	options: [ commandOptions.optionalApplication ]
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		_ = require('lodash')
+		patterns = require('../utils/patterns')
+
 		resin.models.device.get(params.uuid).then (device) ->
 			return options.application or patterns.selectApplication (application) ->
 				return _.all [
@@ -235,6 +248,16 @@ exports.init =
 	permission: 'user'
 	primary: true
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		capitano = Promise.promisifyAll(require('capitano'))
+		rimraf = Promise.promisify(require('rimraf'))
+		tmp = Promise.promisifyAll(require('tmp'))
+		tmp.setGracefulCleanup()
+
+		resin = require('resin-sdk')
+		helpers = require('../utils/helpers')
+		patterns = require('../utils/patterns')
+
 		Promise.try ->
 			return options.application if options.application?
 			return patterns.selectApplication()

--- a/lib/actions/environment-variables.coffee
+++ b/lib/actions/environment-variables.coffee
@@ -1,10 +1,4 @@
-Promise = require('bluebird')
-_ = require('lodash')
-resin = require('resin-sdk')
-visuals = require('resin-cli-visuals')
-events = require('resin-cli-events')
 commandOptions = require('./command-options')
-patterns = require('../utils/patterns')
 
 exports.list =
 	signature: 'envs'
@@ -36,6 +30,11 @@ exports.list =
 	]
 	permission: 'user'
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		_ = require('lodash')
+		resin = require('resin-sdk')
+		visuals = require('resin-cli-visuals')
+
 		Promise.try ->
 			if options.application?
 				return resin.models.environmentVariables.getAllByApplication(options.application)
@@ -83,6 +82,10 @@ exports.remove =
 	]
 	permission: 'user'
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+		patterns = require('../utils/patterns')
+
 		patterns.confirm(options.yes, 'Are you sure you want to delete the environment variable?').then ->
 			if options.device
 				resin.models.environmentVariables.device.remove(params.id)
@@ -119,6 +122,10 @@ exports.add =
 	]
 	permission: 'user'
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+
 		Promise.try ->
 			if not params.value?
 				params.value = process.env[params.key]
@@ -155,6 +162,10 @@ exports.rename =
 	permission: 'user'
 	options: [ commandOptions.booleanDevice ]
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+
 		Promise.try ->
 			if options.device
 				resin.models.environmentVariables.device.update(params.id, params.value).then ->

--- a/lib/actions/info.coffee
+++ b/lib/actions/info.coffee
@@ -1,5 +1,3 @@
-packageJSON = require('../../package.json')
-
 exports.version =
 	signature: 'version'
 	description: 'output the version number'
@@ -7,5 +5,6 @@ exports.version =
 		Display the Resin CLI version.
 	'''
 	action: (params, options, done) ->
+		packageJSON = require('../../package.json')
 		console.log(packageJSON.version)
 		return done()

--- a/lib/actions/keys.coffee
+++ b/lib/actions/keys.coffee
@@ -1,12 +1,4 @@
-Promise = require('bluebird')
-fs = Promise.promisifyAll(require('fs'))
-_ = require('lodash')
-resin = require('resin-sdk')
-capitano = require('capitano')
-visuals = require('resin-cli-visuals')
-events = require('resin-cli-events')
 commandOptions = require('./command-options')
-patterns = require('../utils/patterns')
 
 exports.list =
 	signature: 'keys'
@@ -20,6 +12,9 @@ exports.list =
 	'''
 	permission: 'user'
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		visuals = require('resin-cli-visuals')
+
 		resin.models.key.getAll().then (keys) ->
 			console.log visuals.table.horizontal keys, [
 				'id'
@@ -39,6 +34,9 @@ exports.info =
 	'''
 	permission: 'user'
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		visuals = require('resin-cli-visuals')
+
 		resin.models.key.get(params.id).then (key) ->
 			console.log visuals.table.vertical key, [
 				'id'
@@ -68,6 +66,10 @@ exports.remove =
 	options: [ commandOptions.yes ]
 	permission: 'user'
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+		patterns = require('../utils/patterns')
+
 		patterns.confirm(options.yes, 'Are you sure you want to delete the key?').then ->
 			resin.models.key.remove(params.id)
 		.tap ->
@@ -90,6 +92,13 @@ exports.add =
 	'''
 	permission: 'user'
 	action: (params, options, done) ->
+		_ = require('lodash')
+		Promise = require('bluebird')
+		fs = Promise.promisifyAll(require('fs'))
+		capitano = require('capitano')
+		resin = require('resin-sdk')
+		events = require('resin-cli-events')
+
 		Promise.try ->
 			return fs.readFileAsync(params.path, encoding: 'utf8') if params.path?
 

--- a/lib/actions/logs.coffee
+++ b/lib/actions/logs.coffee
@@ -1,6 +1,3 @@
-_ = require('lodash')
-resin = require('resin-sdk')
-
 module.exports =
 	signature: 'logs <uuid>'
 	description: 'show device logs'
@@ -31,6 +28,9 @@ module.exports =
 	permission: 'user'
 	primary: true
 	action: (params, options, done) ->
+		_ = require('lodash')
+		resin = require('resin-sdk')
+
 		promise = resin.logs.history(params.uuid).each (line) ->
 			console.log(line.message)
 

--- a/lib/actions/notes.coffee
+++ b/lib/actions/notes.coffee
@@ -1,7 +1,3 @@
-Promise = require('bluebird')
-_ = require('lodash')
-resin = require('resin-sdk')
-
 exports.set =
 	signature: 'note <|note>'
 	description: 'set a device note'
@@ -26,6 +22,10 @@ exports.set =
 	]
 	permission: 'user'
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		_ = require('lodash')
+		resin = require('resin-sdk')
+
 		Promise.try ->
 			if _.isEmpty(params.note)
 				throw new Error('Missing note content')

--- a/lib/actions/os.coffee
+++ b/lib/actions/os.coffee
@@ -1,17 +1,4 @@
-fs = require('fs')
-_ = require('lodash')
-Promise = require('bluebird')
-umount = Promise.promisifyAll(require('umount'))
-unzip = require('unzip2')
-rindle = require('rindle')
-resin = require('resin-sdk')
-manager = require('resin-image-manager')
-visuals = require('resin-cli-visuals')
-form = require('resin-cli-form')
-init = require('resin-device-init')
 commandOptions = require('./command-options')
-helpers = require('../utils/helpers')
-patterns = require('../utils/patterns')
 
 exports.download =
 	signature: 'os download <type>'
@@ -32,6 +19,12 @@ exports.download =
 		required: 'You have to specify an output location'
 	]
 	action: (params, options, done) ->
+		unzip = require('unzip2')
+		fs = require('fs')
+		rindle = require('rindle')
+		manager = require('resin-image-manager')
+		visuals = require('resin-cli-visuals')
+
 		console.info("Getting device operating system for #{params.type}")
 
 		manager.get(params.type).then (stream) ->
@@ -61,6 +54,11 @@ exports.download =
 		.nodeify(done)
 
 stepHandler = (step) ->
+	_ = require('lodash')
+	rindle = require('rindle')
+	visuals = require('resin-cli-visuals')
+	helpers = require('../utils/helpers')
+
 	step.on('stdout', _.bind(process.stdout.write, process.stdout))
 	step.on('stderr', _.bind(process.stderr.write, process.stderr))
 
@@ -92,6 +90,12 @@ exports.configure =
 		alias: 'v'
 	]
 	action: (params, options, done) ->
+		_ = require('lodash')
+		resin = require('resin-sdk')
+		form = require('resin-cli-form')
+		init = require('resin-device-init')
+		helpers = require('../utils/helpers')
+
 		console.info('Configuring operating system image')
 		resin.models.device.get(params.uuid)
 			.get('device_type')
@@ -141,6 +145,13 @@ exports.initialize =
 	]
 	root: true
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		umount = Promise.promisifyAll(require('umount'))
+		resin = require('resin-sdk')
+		form = require('resin-cli-form')
+		init = require('resin-device-init')
+		patterns = require('../utils/patterns')
+
 		console.info('Initializing device')
 		resin.models.device.getManifestBySlug(options.type)
 			.then (manifest) ->

--- a/lib/actions/settings.coffee
+++ b/lib/actions/settings.coffee
@@ -1,6 +1,3 @@
-resin = require('resin-sdk')
-prettyjson = require('prettyjson')
-
 exports.list =
 	signature: 'settings'
 	description: 'print current settings'
@@ -12,6 +9,9 @@ exports.list =
 			$ resin settings
 	'''
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
+		prettyjson = require('prettyjson')
+
 		resin.settings.getAll()
 			.then(prettyjson.render)
 			.then(console.log)

--- a/lib/actions/wizard.coffee
+++ b/lib/actions/wizard.coffee
@@ -1,8 +1,3 @@
-Promise = require('bluebird')
-capitano = Promise.promisifyAll(require('capitano'))
-resin = require('resin-sdk')
-patterns = require('../utils/patterns')
-
 exports.wizard =
 	signature: 'quickstart [name]'
 	description: 'getting started with resin.io'
@@ -24,6 +19,11 @@ exports.wizard =
 	permission: 'user'
 	primary: true
 	action: (params, options, done) ->
+		Promise = require('bluebird')
+		capitano = Promise.promisifyAll(require('capitano'))
+		resin = require('resin-sdk')
+		patterns = require('../utils/patterns')
+
 		Promise.try ->
 			return if params.name?
 			patterns.selectOrCreateApplication().tap (applicationName) ->


### PR DESCRIPTION
In my system (MBPr 13), printing the current version takes over 2
seconds:

```sh
$ time ./bin/resin version
2.4.0
./bin/resin version  1.37s user 0.19s system 73% cpu 2.130 total
```

The CLI takes almost all of these time to parse the dependency tree
before returning control over the actually called command.

To mitigate this problem, we only require the NPM dependencies a command
requires when executing such command, and thus prevent dependencies from
being required and parsed unnecessary.

After this improvement, printing the original example (`resin version`)
returns in less than a second (2x improvement):

```sh
$ time ./bin/resin version
2.4.0
./bin/resin version  0.88s user 0.09s system 102% cpu 0.938 total
```