### PR TITLE
Don't make `device init` a primary command

### DIFF
--- a/build/actions/device.js
+++ b/build/actions/device.js
@@ -191,7 +191,6 @@ limitations under the License.
       }
     ],
     permission: 'user',
-    primary: true,
     action: function(params, options, done) {
       var Promise, capitano, helpers, patterns, resin, rimraf, tmp;
       Promise = require('bluebird');

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -262,7 +262,6 @@ exports.init =
 		}
 	]
 	permission: 'user'
-	primary: true
 	action: (params, options, done) ->
 		Promise = require('bluebird')
 		capitano = Promise.promisifyAll(require('capitano'))


### PR DESCRIPTION
Unlikely that a user will run this directly having the more high level
`quickstart`.