### PR TITLE
Remove registered device resource in case of errors in quickstart

### DIFF
--- a/build/actions/device.js
+++ b/build/actions/device.js
@@ -226,6 +226,10 @@ limitations under the License.
               var message;
               message = 'Initializing a device requires administration permissions\ngiven that we need to access raw devices directly.\n';
               return helpers.sudo(['os', 'initialize', temporalPath, '--type', application.device_type], message);
+            })["catch"](function(error) {
+              return resin.models.device.remove(device.uuid)["finally"](function() {
+                throw error;
+              });
             });
           });
         }).then(function(device) {

--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -299,6 +299,12 @@ exports.init =
 							'''
 
 							helpers.sudo([ 'os', 'initialize', temporalPath, '--type', application.device_type ], message)
+
+						# Make sure the device resource is removed if there is an
+						# error when configuring or initializing a device image
+						.catch (error) ->
+							resin.models.device.remove(device.uuid).finally ->
+								throw error
 			.then (device) ->
 				console.log('Done')
 				return device.uuid


### PR DESCRIPTION
A device resource needs to be registered with the API before being able
to create the `config.json` file that goes in a device.

This means thats the device image is configured and written to an
external drive (e.g: SDCard) *after* the device resource registered.

If any of the above operations fail, there will be an unitialized orphan
device living in the selected application that the user will have to
remove himself.