### PR TITLE
Upgrade Resin SDK to v5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "resin-device-init": "^2.0.0",
     "resin-image-manager": "^3.2.2",
     "resin-pine": "^1.3.0",
-    "resin-sdk": "^4.1.2",
+    "resin-sdk": "^5.0.1",
     "resin-settings-client": "^3.1.0",
     "resin-vcs": "^2.0.0",
     "rimraf": "^2.4.3",


### PR DESCRIPTION
This breaking change doesn't affect the CLI in any way, so we can
upgrade directly.