### PR TITLE
Remove build status CI badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Resin CLI
 
 [![npm version](https://badge.fury.io/js/resin-cli.svg)](http://badge.fury.io/js/resin-cli)
 [![dependencies](https://david-dm.org/resin-io/resin-cli.png)](https://david-dm.org/resin-io/resin-cli.png)
-[![Build Status](https://travis-ci.org/resin-io/resin-cli.svg?branch=master)](https://travis-ci.org/resin-io/resin-cli)
-[![Build status](https://ci.appveyor.com/api/projects/status/45i7d0m0patxj420?svg=true)](https://ci.appveyor.com/project/jviotti/resin-cli)
 
 Join our online chat at [![Gitter chat](https://badges.gitter.im/resin-io/chat.png)](https://gitter.im/resin-io/chat)
 


### PR DESCRIPTION
CI integration was removed in
https://github.com/resin-io/resin-cli/commit/96f0b5fbd6d46bf6c208dd6d1c3e7ce1e2aa8b09,
but it looks like we forgot to remove the badges.