### PR TITLE
Refer to device uuids in command help

### DIFF
--- a/build/actions/command-options.js
+++ b/build/actions/command-options.js
@@ -41,13 +41,13 @@ limitations under the License.
   exports.optionalDevice = {
     signature: 'device',
     parameter: 'device',
-    description: 'device name',
+    description: 'device uuid',
     alias: 'd'
   };
 
   exports.booleanDevice = {
     signature: 'device',
-    description: 'device name',
+    description: 'device',
     boolean: true,
     alias: 'd'
   };

--- a/lib/actions/command-options.coffee
+++ b/lib/actions/command-options.coffee
@@ -35,12 +35,12 @@ exports.application = _.defaults
 exports.optionalDevice =
 	signature: 'device'
 	parameter: 'device'
-	description: 'device name'
+	description: 'device uuid'
 	alias: 'd'
 
 exports.booleanDevice =
 	signature: 'device'
-	description: 'device name'
+	description: 'device'
 	boolean: true
 	alias: 'd'
 


### PR DESCRIPTION
Currently the CLI asks for a device "name" on device options while it
actually needs a "uuid".

Fixes: https://github.com/resin-io/resin-cli/issues/309