### PR TITLE
Force update alert to be always shown

### DIFF
--- a/build/utils/update.js
+++ b/build/utils/update.js
@@ -26,7 +26,8 @@ limitations under the License.
 
   if (!isRoot()) {
     notifier = updateNotifier({
-      pkg: packageJSON
+      pkg: packageJSON,
+      updateCheckInterval: 0
     });
   }
 

--- a/lib/utils/update.coffee
+++ b/lib/utils/update.coffee
@@ -22,7 +22,13 @@ packageJSON = require('../../package.json')
 # running time ask for updated, however this can lead
 # to ugly EPERM issues if those files are created as root.
 if not isRoot()
-	notifier = updateNotifier(pkg: packageJSON)
+	notifier = updateNotifier
+		pkg: packageJSON
+
+		# Force update notification alert
+		# to be shown every time there is
+		# an update.
+		updateCheckInterval: 0
 
 exports.hasAvailableUpdate = ->
 	return notifier?


### PR DESCRIPTION
If `updateCheckInterval` has any meanginful value, the alert will be
shown one out of ten times, or something like that, making the user
likely to miss updates.

The underlying issue is that `update-notifier`, if it detects a cached
update notification, it deletes it, and only attempts to show it back if
`updateCheckInterval` is greater than `Date.now() - lastUpdateCheck`.