### PR TITLE
Only throw "Invalid 2FA code" if we're sure that's the cause

### DIFF
--- a/build/utils/patterns.js
+++ b/build/utils/patterns.js
@@ -56,9 +56,12 @@ limitations under the License.
         message: 'Two factor auth challenge:',
         name: 'code',
         type: 'input'
-      }).then(resin.auth.twoFactor.challenge)["catch"](function() {
+      }).then(resin.auth.twoFactor.challenge)["catch"](function(error) {
         return resin.auth.logout().then(function() {
-          throw new Error('Invalid two factor authentication code');
+          if (error.name === 'ResinRequestError' && error.statusCode === 401) {
+            throw new Error('Invalid two factor authentication code');
+          }
+          throw error;
         });
       });
     });

--- a/lib/utils/patterns.coffee
+++ b/lib/utils/patterns.coffee
@@ -44,9 +44,11 @@ exports.authenticate = (options) ->
 			name: 'code'
 			type: 'input'
 		.then(resin.auth.twoFactor.challenge)
-		.catch ->
+		.catch (error) ->
 			resin.auth.logout().then ->
-				throw new Error('Invalid two factor authentication code')
+				if error.name is 'ResinRequestError' and error.statusCode is 401
+					throw new Error('Invalid two factor authentication code')
+				throw error
 
 exports.askLoginType = ->
 	return form.ask


### PR DESCRIPTION
Currently, such error will be thrown when
`resin.auth.twoFactor.challenge()` rejects, but an invalid code is not
the only thing this function can reject for.