### PR TITLE
Log CLI events based on original command signature

### DIFF
--- a/build/events.js
+++ b/build/events.js
@@ -1,5 +1,5 @@
 (function() {
-  var Mixpanel, Promise, _, packageJSON, resin;
+  var Mixpanel, Promise, _, capitanoState, packageJSON, resin;
 
   _ = require('lodash');
 
@@ -8,6 +8,8 @@
   Promise = require('bluebird');
 
   resin = require('resin-sdk');
+
+  capitanoState = Promise.promisifyAll(require('capitano').state);
 
   packageJSON = require('../package.json');
 
@@ -21,15 +23,17 @@
       username: resin.auth.whoami(),
       mixpanel: exports.getLoggerInstance()
     }).then(function(data) {
-      return data.mixpanel.track("[CLI] " + capitanoCommand.command, {
-        distinct_id: data.username,
-        argv: process.argv.join(' '),
-        version: packageJSON.version,
-        node: process.version,
-        arch: process.arch,
-        resinUrl: data.resinUrl,
-        platform: process.platform,
-        command: capitanoCommand
+      return capitanoState.getMatchCommandAsync(capitanoCommand.command).then(function(command) {
+        return data.mixpanel.track("[CLI] " + (command.signature.toString()), {
+          distinct_id: data.username,
+          argv: process.argv.join(' '),
+          version: packageJSON.version,
+          node: process.version,
+          arch: process.arch,
+          resinUrl: data.resinUrl,
+          platform: process.platform,
+          command: capitanoCommand
+        });
       });
     });
   };

--- a/lib/events.coffee
+++ b/lib/events.coffee
@@ -2,6 +2,7 @@ _ = require('lodash')
 Mixpanel = require('mixpanel')
 Promise = require('bluebird')
 resin = require('resin-sdk')
+capitanoState = Promise.promisifyAll(require('capitano').state)
 packageJSON = require('../package.json')
 
 exports.getLoggerInstance = _.memoize ->
@@ -13,12 +14,13 @@ exports.trackCommand = (capitanoCommand) ->
 		username: resin.auth.whoami()
 		mixpanel: exports.getLoggerInstance()
 	.then (data) ->
-		data.mixpanel.track "[CLI] #{capitanoCommand.command}",
-			distinct_id: data.username
-			argv: process.argv.join(' ')
-			version: packageJSON.version
-			node: process.version
-			arch: process.arch
-			resinUrl: data.resinUrl
-			platform: process.platform
-			command: capitanoCommand
+		return capitanoState.getMatchCommandAsync(capitanoCommand.command).then (command) ->
+			data.mixpanel.track "[CLI] #{command.signature.toString()}",
+				distinct_id: data.username
+				argv: process.argv.join(' ')
+				version: packageJSON.version
+				node: process.version
+				arch: process.arch
+				resinUrl: data.resinUrl
+				platform: process.platform
+				command: capitanoCommand


### PR DESCRIPTION
Currently we log a CLI event with the passed command, however this might
include usr params, like a uuid, and therefore cause thousands of
different event names in Mixpanel.