### PR TITLE
Change sync description

### DIFF
--- a/build/actions/sync.js
+++ b/build/actions/sync.js
@@ -19,7 +19,7 @@ limitations under the License.
   module.exports = {
     signature: 'sync <uuid>',
     description: '(beta) sync your changes with a device',
-    help: 'Use this command to sync your local changes to a certain device on the fly.\n\nYou can save all the options mentioned below in a `resin-sync.yml` file,\nby using the same option names as keys. For example:\n\n	$ cat $PWD/resin-sync.yml\n	source: src/\n	before: \'echo Hello\'\n	exec: \'python main.py\'\n	ignore:\n		- .git\n		- node_modules/\n	progress: true\n\nNotice that explicitly passed command options override the ones set in the configuration file.\n\nExamples:\n\n	$ resin sync 7cf02a6\n	$ resin sync 7cf02a6 --port 8080\n	$ resin sync 7cf02a6 --ignore foo,bar',
+    help: 'Use this command to sync your local changes to a certain device on the fly.\n\nYou can save all the options mentioned below in a `resin-sync.yml` file,\nby using the same option names as keys. For example:\n\n	$ cat $PWD/resin-sync.yml\n	source: src/\n	before: \'echo Hello\'\n	ignore:\n		- .git\n		- node_modules/\n	progress: true\n\nNotice that explicitly passed command options override the ones set in the configuration file.\n\nExamples:\n\n	$ resin sync 7cf02a6\n	$ resin sync 7cf02a6 --port 8080\n	$ resin sync 7cf02a6 --ignore foo,bar',
     permission: 'user',
     primary: true,
     options: [
@@ -38,11 +38,6 @@ limitations under the License.
         parameter: 'command',
         description: 'execute a command before syncing',
         alias: 'b'
-      }, {
-        signature: 'exec',
-        parameter: 'command',
-        description: 'execute a command after syncing (on the device)',
-        alias: 'x'
       }, {
         signature: 'progress',
         boolean: true,

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -588,7 +588,6 @@ by using the same option names as keys. For example:
 	$ cat $PWD/resin-sync.yml
 	source: src/
 	before: 'echo Hello'
-	exec: 'python main.py'
 	ignore:
 		- .git
 		- node_modules/
@@ -615,10 +614,6 @@ comma delimited paths to ignore when syncing
 #### --before, -b &#60;command&#62;
 
 execute a command before syncing
-
-#### --exec, -x &#60;command&#62;
-
-execute a command after syncing (on the device)
 
 #### --progress, -p
 

--- a/lib/actions/sync.coffee
+++ b/lib/actions/sync.coffee
@@ -26,7 +26,6 @@ module.exports =
 			$ cat $PWD/resin-sync.yml
 			source: src/
 			before: 'echo Hello'
-			exec: 'python main.py'
 			ignore:
 				- .git
 				- node_modules/
@@ -57,11 +56,6 @@ module.exports =
 			parameter: 'command'
 			description: 'execute a command before syncing'
 			alias: 'b'
-		,
-			signature: 'exec'
-			parameter: 'command'
-			description: 'execute a command after syncing (on the device)'
-			alias: 'x'
 		,
 			signature: 'progress'
 			boolean: true

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "resin-image-manager": "^4.0.0",
     "resin-pine": "^1.3.0",
     "resin-sdk": "^5.2.0",
-    "resin-settings-client": "^3.1.0",
+    "resin-settings-client": "^3.5.0",
     "resin-sync": "^1.0.0",
     "resin-vcs": "^2.0.0",
     "rimraf": "^2.4.3",


### PR DESCRIPTION
Remove the 'exec after rsync' feature description which is not supported by ssh gateway for now.