### PR TITLE
Implement a function to attempt to infer a device selection

### DIFF
--- a/build/utils/patterns.js
+++ b/build/utils/patterns.js
@@ -191,6 +191,32 @@ limitations under the License.
     });
   };
 
+  exports.inferOrSelectDevice = function(applicationName) {
+    return Promise["try"](function() {
+      if (applicationName != null) {
+        return resin.models.device.getAllByApplication(applicationName);
+      }
+      return resin.models.device.getAll();
+    }).then(function(devices) {
+      if (_.isEmpty(devices)) {
+        throw new Error('You don\'t have any devices');
+      }
+      if (devices.length === 1) {
+        return _.first(devices).uuid;
+      }
+      return form.ask({
+        message: 'Select a device',
+        type: 'list',
+        choices: _.map(devices, function(device) {
+          return {
+            name: (device.name || 'Untitled') + " (" + (device.uuid.slice(0, 7)) + ")",
+            value: device.uuid
+          };
+        })
+      });
+    });
+  };
+
   exports.printErrorMessage = function(message) {
     console.error(chalk.red(message));
     return console.error(chalk.red("\n" + messages.getHelp + "\n"));

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -69,7 +69,7 @@ Now you have access to all the commands referenced below.
 
 - Sync
 
-	- [sync &#60;uuid&#62;](#sync-60-uuid-62-)
+	- [sync [source]](#sync-source-)
 
 - Notes
 
@@ -578,9 +578,11 @@ continuously stream output
 
 # Sync
 
-## sync &#60;uuid&#62;
+## sync [source]
 
 Use this command to sync your local changes to a certain device on the fly.
+
+The `source` argument can be either a device uuid or an application name.
 
 You can save all the options mentioned below in a `resin-sync.yml` file,
 by using the same option names as keys. For example:
@@ -597,6 +599,7 @@ Notice that explicitly passed command options override the ones set in the confi
 
 Examples:
 
+	$ resin sync MyApp
 	$ resin sync 7cf02a6
 	$ resin sync 7cf02a6 --port 8080
 	$ resin sync 7cf02a6 --ignore foo,bar

--- a/lib/actions/sync.coffee
+++ b/lib/actions/sync.coffee
@@ -15,10 +15,12 @@ limitations under the License.
 ###
 
 module.exports =
-	signature: 'sync <uuid>'
+	signature: 'sync [source]'
 	description: '(beta) sync your changes with a device'
 	help: '''
 		Use this command to sync your local changes to a certain device on the fly.
+
+		The `source` argument can be either a device uuid or an application name.
 
 		You can save all the options mentioned below in a `resin-sync.yml` file,
 		by using the same option names as keys. For example:
@@ -35,6 +37,7 @@ module.exports =
 
 		Examples:
 
+			$ resin sync MyApp
 			$ resin sync 7cf02a6
 			$ resin sync 7cf02a6 --port 8080
 			$ resin sync 7cf02a6 --ignore foo,bar
@@ -68,10 +71,19 @@ module.exports =
 			alias: 't'
 	]
 	action: (params, options, done) ->
+		resin = require('resin-sdk')
 		resinSync = require('resin-sync')
+		patterns = require('../utils/patterns')
 
 		# TODO: Add comma separated options to Capitano
 		if options.ignore?
 			options.ignore = options.ignore.split(',')
 
-		resinSync.sync(params.uuid, options).nodeify(done)
+		resin.models.device.has(params.source).then (isValidUUID) ->
+			if isValidUUID
+				return params.source
+
+			return patterns.inferOrSelectDevice(params.source)
+		.then (uuid) ->
+			resinSync.sync(uuid, options)
+		.nodeify(done)

--- a/lib/utils/patterns.coffee
+++ b/lib/utils/patterns.coffee
@@ -150,6 +150,27 @@ exports.awaitDevice = (uuid) ->
 		console.info("Waiting for #{deviceName} to connect to resin...")
 		poll().return(uuid)
 
+exports.inferOrSelectDevice = (applicationName) ->
+	Promise.try ->
+		if applicationName?
+			return resin.models.device.getAllByApplication(applicationName)
+		return resin.models.device.getAll()
+	.then (devices) ->
+		if _.isEmpty(devices)
+			throw new Error('You don\'t have any devices')
+
+		if devices.length is 1
+			return _.first(devices).uuid
+
+		return form.ask
+			message: 'Select a device'
+			type: 'list'
+			choices: _.map devices, (device) ->
+				return {
+					name: "#{device.name or 'Untitled'} (#{device.uuid.slice(0, 7)})"
+					value: device.uuid
+				}
+
 exports.printErrorMessage = (message) ->
 	console.error(chalk.red(message))
 	console.error(chalk.red("\n#{messages.getHelp}\n"))


### PR DESCRIPTION
Attempt to infer the device uuid in `resin sync`

This PR adds functionality to `resin sync` to try to infer what the
device uuid is as follows:

- If the argument to `resin sync` is an app, get all the devices from
that application. If there is only one, auto-select it, otherwise show
an interactive drive selection widget.

- If the argument to `resin sync` is a uuid, use it directly, without
trying to infer anything.

- If no argument is passed to `resin sync`, display an interactive
selection widget showing all your devices from all your applications.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>
