### PR TITLE
Feature/sync ssh device autochoose

### DIFF
--- a/build/actions/sync.js
+++ b/build/actions/sync.js
@@ -17,9 +17,9 @@ limitations under the License.
 
 (function() {
   module.exports = {
-    signature: 'sync [source]',
+    signature: 'sync [destination]',
     description: '(beta) sync your changes with a device',
-    help: 'WARNING: If you\'re running Windows, this command only supports `cmd.exe`.\n\nUse this command to sync your local changes to a certain device on the fly.\n\nThe `source` argument can be either a device uuid or an application name.\n\nYou can save all the options mentioned below in a `resin-sync.yml` file,\nby using the same option names as keys. For example:\n\n	$ cat $PWD/resin-sync.yml\n	source: src/\n	before: \'echo Hello\'\n	ignore:\n		- .git\n		- node_modules/\n	progress: true\n	verbose: false\n\nNotice that explicitly passed command options override the ones set in the configuration file.\n\nExamples:\n\n	$ resin sync MyApp\n	$ resin sync 7cf02a6\n	$ resin sync 7cf02a6 --port 8080\n	$ resin sync 7cf02a6 --ignore foo,bar\n	$ resin sync 7cf02a6 -v',
+    help: 'WARNING: If you\'re running Windows, this command only supports `cmd.exe`.\n\nUse this command to sync your local changes to a certain device on the fly.\n\nThe `destination` argument can be either a device uuid or an application name.\n\nYou can save all the options mentioned below in a `resin-sync.yml` file,\nby using the same option names as keys. For example:\n\n	$ cat $PWD/resin-sync.yml\n	source: src/\n	before: \'echo Hello\'\n	ignore:\n		- .git\n		- node_modules/\n	progress: true\n	verbose: false\n\nNotice that explicitly passed command options override the ones set in the configuration file.\n\nExamples:\n\n	$ resin sync MyApp\n	$ resin sync 7cf02a6\n	$ resin sync 7cf02a6 --port 8080\n	$ resin sync 7cf02a6 --ignore foo,bar\n	$ resin sync 7cf02a6 -v',
     permission: 'user',
     primary: true,
     options: [
@@ -63,11 +63,11 @@ limitations under the License.
       if (options.ignore != null) {
         options.ignore = options.ignore.split(',');
       }
-      return resin.models.device.has(params.source).then(function(isValidUUID) {
+      return resin.models.device.has(params.destination).then(function(isValidUUID) {
         if (isValidUUID) {
-          return params.source;
+          return params.destination;
         }
-        return patterns.inferOrSelectDevice(params.source);
+        return patterns.inferOrSelectDevice(params.destination);
       }).then(function(uuid) {
         return resinSync.sync(uuid, options);
       }).nodeify(done);

--- a/lib/actions/sync.coffee
+++ b/lib/actions/sync.coffee
@@ -15,14 +15,14 @@ limitations under the License.
 ###
 
 module.exports =
-	signature: 'sync [source]'
+	signature: 'sync [destination]'
 	description: '(beta) sync your changes with a device'
 	help: '''
 		WARNING: If you're running Windows, this command only supports `cmd.exe`.
 
 		Use this command to sync your local changes to a certain device on the fly.
 
-		The `source` argument can be either a device uuid or an application name.
+		The `destination` argument can be either a device uuid or an application name.
 
 		You can save all the options mentioned below in a `resin-sync.yml` file,
 		by using the same option names as keys. For example:
@@ -89,11 +89,11 @@ module.exports =
 		if options.ignore?
 			options.ignore = options.ignore.split(',')
 
-		resin.models.device.has(params.source).then (isValidUUID) ->
+		resin.models.device.has(params.destination).then (isValidUUID) ->
 			if isValidUUID
-				return params.source
+				return params.destination
 
-			return patterns.inferOrSelectDevice(params.source)
+			return patterns.inferOrSelectDevice(params.destination)
 		.then (uuid) ->
 			resinSync.sync(uuid, options)
 		.nodeify(done)


### PR DESCRIPTION
Closes #360 

This PR:

1. Changes the resin sync/ssh parameter name from `source` to `destination` so help is a bit more meaningful:

	```
	sync [destination]                  (beta) sync your changes with a device                       
	ssh [destination]                   (beta) get a shell into the running app container of a device
	```

2. Implements device inference and autoselect if there is a single device for `resin ssh`, so `resin sync` and `resin ssh` have consistent usage pattern