### PR TITLE
resin sync/ssh improvements

### DIFF
--- a/build/actions/ssh.js
+++ b/build/actions/ssh.js
@@ -35,9 +35,9 @@ limitations under the License.
   };
 
   module.exports = {
-    signature: 'ssh [destination]',
+    signature: 'ssh [uuid]',
     description: '(beta) get a shell into the running app container of a device',
-    help: 'WARNING: If you\'re running Windows, this command only supports `cmd.exe`.\n\nUse this command to get a shell into the running application container of\nyour device.\n\nThe `destination` argument can be either a device uuid or an application name.\n\nExamples:\n\n	$ resin ssh MyApp\n	$ resin ssh 7cf02a6\n	$ resin ssh 7cf02a6 --port 8080\n	$ resin ssh 7cf02a6 -v',
+    help: 'WARNING: If you\'re running Windows, this command only supports `cmd.exe`.\n\nUse this command to get a shell into the running application container of\nyour device.\n\nExamples:\n\n	$ resin ssh MyApp\n	$ resin ssh 7cf02a6\n	$ resin ssh 7cf02a6 --port 8080\n	$ resin ssh 7cf02a6 -v',
     permission: 'user',
     primary: true,
     options: [
@@ -45,7 +45,7 @@ limitations under the License.
         signature: 'port',
         parameter: 'port',
         description: 'ssh gateway port',
-        alias: 't'
+        alias: 'p'
       }, {
         signature: 'verbose',
         boolean: true,
@@ -64,11 +64,11 @@ limitations under the License.
         options.port = 22;
       }
       verbose = options.verbose ? '-vvv' : '';
-      return resin.models.device.has(params.destination).then(function(isValidUUID) {
+      return resin.models.device.has(params.uuid).then(function(isValidUUID) {
         if (isValidUUID) {
-          return params.destination;
+          return params.uuid;
         }
-        return patterns.inferOrSelectDevice(params.destination);
+        return patterns.inferOrSelectDevice();
       }).then(function(uuid) {
         console.info("Connecting with: " + uuid);
         return resin.models.device.get(uuid);
@@ -88,7 +88,7 @@ limitations under the License.
           }
           return Promise["try"](function() {
             var command, spawn, subShellCommand;
-            command = "ssh " + verbose + " -t -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p " + options.port + " " + username + "@ssh." + (settings.get('proxyUrl')) + " enter " + uuid + " " + containerId;
+            command = "ssh " + verbose + " -t -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlMaster=no -p " + options.port + " " + username + "@ssh." + (settings.get('proxyUrl')) + " enter " + uuid + " " + containerId;
             subShellCommand = getSubShellCommand(command);
             return spawn = child_process.spawn(subShellCommand.program, subShellCommand.args, {
               stdio: 'inherit'

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -69,11 +69,11 @@ Now you have access to all the commands referenced below.
 
 - Sync
 
-	- [sync [source]](#sync-source-)
+	- [sync [uuid]](#sync-uuid-)
 
 - SSH
 
-	- [ssh &#60;uuid&#62;](#ssh-60-uuid-62-)
+	- [ssh [uuid]](#ssh-uuid-)
 
 - Notes
 
@@ -582,57 +582,74 @@ continuously stream output
 
 # Sync
 
-## sync [source]
+## sync [uuid]
 
 WARNING: If you're running Windows, this command only supports `cmd.exe`.
 
 Use this command to sync your local changes to a certain device on the fly.
 
-The `source` argument can be either a device uuid or an application name.
+After every 'resin sync' the updated settings will be saved in
+'<source>/.resin-sync.yml' and will be used in later invocations. You can
+also change any option by editing '.resin-sync.yml' directly.
 
-You can save all the options mentioned below in a `resin-sync.yml` file,
-by using the same option names as keys. For example:
+Here is an example '.resin-sync.yml' :
 
-	$ cat $PWD/resin-sync.yml
-	source: src/
+	$ cat $PWD/.resin-sync.yml
+	uuid: 7cf02a6
+	destination: '/usr/src/app'
 	before: 'echo Hello'
+	after: 'echo Done'
 	ignore:
 		- .git
 		- node_modules/
-	progress: true
-	verbose: false
 
-Notice that explicitly passed command options override the ones set in the configuration file.
+Command line options have precedence over the ones saved in '.resin-sync.yml'.
+
+If '.gitignore' is found in the source directory then all explicitly listed files will be
+excluded from the syncing process. You can choose to change this default behavior with the
+'--skip-gitignore' option.
 
 Examples:
 
-	$ resin sync MyApp
-	$ resin sync 7cf02a6
-	$ resin sync 7cf02a6 --port 8080
-	$ resin sync 7cf02a6 --ignore foo,bar
-	$ resin sync 7cf02a6 -v
+	$ resin sync 7cf02a6 --source . --destination /usr/src/app
+	$ resin sync 7cf02a6 -s /home/user/myResinProject -d /usr/src/app --before 'echo Hello' --after 'echo Done'
+	$ resin sync --ignore lib/
+	$ resin sync --verbose false
+	$ resin sync
 
 ### Options
 
 #### --source, -s &#60;path&#62;
 
-custom source path
+local directory path to synchronize to device
+
+#### --destination, -d &#60;path&#62;
+
+destination path on device
 
 #### --ignore, -i &#60;paths&#62;
 
 comma delimited paths to ignore when syncing
 
+#### --skip-gitignore
+
+do not parse excluded/included files from .gitignore
+
 #### --before, -b &#60;command&#62;
 
 execute a command before syncing
 
-#### --progress, -p
+#### --after, -a &#60;command&#62;
 
-show progress
+execute a command after syncing
 
 #### --port, -t &#60;port&#62;
 
 ssh port
+
+#### --progress, -p
+
+show progress
 
 #### --verbose, -v
 
@@ -640,7 +657,7 @@ increase verbosity
 
 # SSH
 
-## ssh &#60;uuid&#62;
+## ssh [uuid]
 
 WARNING: If you're running Windows, this command only supports `cmd.exe`.
 
@@ -649,13 +666,14 @@ your device.
 
 Examples:
 
+	$ resin ssh MyApp
 	$ resin ssh 7cf02a6
 	$ resin ssh 7cf02a6 --port 8080
 	$ resin ssh 7cf02a6 -v
 
 ### Options
 
-#### --port, -t &#60;port&#62;
+#### --port, -p &#60;port&#62;
 
 ssh gateway port
 

--- a/lib/actions/ssh.coffee
+++ b/lib/actions/ssh.coffee
@@ -94,7 +94,11 @@ module.exports =
 			.then ({ username, uuid, containerId }) ->
 				throw new Error('Did not find running application container') if not containerId?
 				Promise.try ->
-					command = "ssh #{verbose} -t -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+					command = "ssh #{verbose} -t \
+						-o LogLevel=ERROR \
+						-o StrictHostKeyChecking=no \
+						-o UserKnownHostsFile=/dev/null \
+						-o ControlMaster=no \
 						-p #{options.port} #{username}@ssh.#{settings.get('proxyUrl')} enter #{uuid} #{containerId}"
 
 					subShellCommand = getSubShellCommand(command)

--- a/lib/actions/ssh.coffee
+++ b/lib/actions/ssh.coffee
@@ -36,15 +36,13 @@ getSubShellCommand = (command) ->
 		}
 
 module.exports =
-	signature: 'ssh [destination]'
+	signature: 'ssh [uuid]'
 	description: '(beta) get a shell into the running app container of a device'
 	help: '''
 		WARNING: If you're running Windows, this command only supports `cmd.exe`.
 
 		Use this command to get a shell into the running application container of
 		your device.
-
-		The `destination` argument can be either a device uuid or an application name.
 
 		Examples:
 
@@ -59,7 +57,7 @@ module.exports =
 			signature: 'port'
 			parameter: 'port'
 			description: 'ssh gateway port'
-			alias: 't'
+			alias: 'p'
 	,
 			signature: 'verbose'
 			boolean: true
@@ -78,11 +76,11 @@ module.exports =
 
 		verbose = if options.verbose then '-vvv' else ''
 
-		resin.models.device.has(params.destination).then (isValidUUID) ->
+		resin.models.device.has(params.uuid).then (isValidUUID) ->
 			if isValidUUID
-				return params.destination
+				return params.uuid
 
-			return patterns.inferOrSelectDevice(params.destination)
+			return patterns.inferOrSelectDevice()
 		.then (uuid) ->
 			console.info("Connecting with: #{uuid}")
 			resin.models.device.get(uuid)

--- a/lib/actions/sync.coffee
+++ b/lib/actions/sync.coffee
@@ -58,6 +58,7 @@ module.exports =
 			uuid: 7cf02a6
 			destination: '/usr/src/app'
 			before: 'echo Hello'
+			after: 'echo Done'
 			ignore:
 				- .git
 				- node_modules/
@@ -71,7 +72,7 @@ module.exports =
 		Examples:
 
 			$ resin sync 7cf02a6 --source '.' --destination '/usr/src/app'
-			$ resin sync 7cf02a6 -s '/home/user/myResinProject' -d '/usr/src/app' --before 'echo Hello'
+			$ resin sync 7cf02a6 -s '/home/user/myResinProject' -d '/usr/src/app' --before 'echo Hello' --after 'echo Done'
 			$ resin sync --ignore 'lib/'
 			$ resin sync --verbose false
 			$ resin sync
@@ -102,6 +103,11 @@ module.exports =
 			parameter: 'command'
 			description: 'execute a command before syncing'
 			alias: 'b'
+		,
+			signature: 'after'
+			parameter: 'command'
+			description: 'execute a command after syncing'
+			alias: 'a'
 		,
 			signature: 'port'
 			parameter: 'port'

--- a/lib/actions/sync.coffee
+++ b/lib/actions/sync.coffee
@@ -71,9 +71,9 @@ module.exports =
 
 		Examples:
 
-			$ resin sync 7cf02a6 --source '.' --destination '/usr/src/app'
-			$ resin sync 7cf02a6 -s '/home/user/myResinProject' -d '/usr/src/app' --before 'echo Hello' --after 'echo Done'
-			$ resin sync --ignore 'lib/'
+			$ resin sync 7cf02a6 --source . --destination /usr/src/app
+			$ resin sync 7cf02a6 -s /home/user/myResinProject -d /usr/src/app --before 'echo Hello' --after 'echo Done'
+			$ resin sync --ignore lib/
 			$ resin sync --verbose false
 			$ resin sync
 	'''

--- a/lib/actions/sync.coffee
+++ b/lib/actions/sync.coffee
@@ -146,10 +146,11 @@ module.exports =
 			if options.ignore?
 				options.ignore = options.ignore.split(',')
 
-			Promise.resolve(params.uuid ? loadConfig(options.source).uuid)
+			Promise.resolve(params.uuid)
 			.then (uuid) ->
 				if not uuid?
-					return patterns.inferOrSelectDevice()
+					savedUuid = loadConfig(options.source).uuid
+					return patterns.inferOrSelectDevice(savedUuid)
 
 				resin.models.device.has(uuid)
 				.then (hasDevice) ->

--- a/lib/actions/sync.coffee
+++ b/lib/actions/sync.coffee
@@ -14,6 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ###
 
+# Loads '.resin-sync.yml' configuration from 'source' directory.
+# Returns the configuration object on success
+#
+# TODO: Use 'config.load()' method from `resin sync` when resin sync gets
+# integrated into resin CLI
+loadConfig = (source) ->
+	fs = require('fs')
+	path = require('path')
+	_ = require('lodash')
+	jsYaml = require('js-yaml')
+
+	configPath = path.join(source, '.resin-sync.yml')
+	try
+		config = fs.readFileSync(configPath, encoding: 'utf8')
+		result = jsYaml.safeLoad(config)
+	catch error
+		# return empty object if '.resin-sync.yml' is missing
+		if error.code is 'ENOENT'
+			return {}
+		throw error
+
+	if not _.isPlainObject(result)
+		throw new Error("Invalid configuration file: #{configPath}")
+
+	return result
+
 module.exports =
 	signature: 'sync [uuid]'
 	description: '(beta) sync your changes to a device'
@@ -97,7 +123,6 @@ module.exports =
 		Promise = require('bluebird')
 		resinSync = require('resin-sync')
 		patterns = require('../utils/patterns')
-		{ loadConfig } = require('../utils/helpers')
 
 		Promise.try ->
 			try

--- a/lib/actions/sync.coffee
+++ b/lib/actions/sync.coffee
@@ -61,13 +61,12 @@ module.exports =
 			ignore:
 				- .git
 				- node_modules/
-			progress: true
-			verbose: false
 
-		Notice that explicitly passed command options override the ones set in the configuration file.
+		Command line options have precedence over the ones saved in '.resin-sync.yml'.
 
-		Also, if '.gitignore' is found in the source directory then all explicitly listed files will be
-		excluded from the syncing process.
+		If '.gitignore' is found in the source directory then all explicitly listed files will be
+		excluded from the syncing process. You can choose to change this default behavior with the
+		'--skip-gitignore' option.
 
 		Examples:
 
@@ -95,20 +94,24 @@ module.exports =
 			description: 'comma delimited paths to ignore when syncing'
 			alias: 'i'
 		,
+			signature: 'skip-gitignore'
+			boolean: true
+			description: 'do not parse excluded/included files from .gitignore'
+		,
 			signature: 'before'
 			parameter: 'command'
 			description: 'execute a command before syncing'
 			alias: 'b'
 		,
-			signature: 'progress'
-			boolean: true
-			description: 'show progress'
-			alias: 'p'
-		,
 			signature: 'port'
 			parameter: 'port'
 			description: 'ssh port'
 			alias: 't'
+		,
+			signature: 'progress'
+			boolean: true
+			description: 'show progress'
+			alias: 'p'
 		,
 			signature: 'verbose'
 			boolean: true

--- a/lib/utils/patterns.coffee
+++ b/lib/utils/patterns.coffee
@@ -161,9 +161,6 @@ exports.inferOrSelectDevice = (applicationName) ->
 		if _.isEmpty(devices)
 			throw new Error('You don\'t have any devices')
 
-		if devices.length is 1
-			return _.first(devices).uuid
-
 		return form.ask
 			message: 'Select a device'
 			type: 'list'

--- a/lib/utils/patterns.coffee
+++ b/lib/utils/patterns.coffee
@@ -150,21 +150,19 @@ exports.awaitDevice = (uuid) ->
 		console.info("Waiting for #{deviceName} to connect to resin...")
 		poll().return(uuid)
 
-exports.inferOrSelectDevice = (applicationName) ->
-	Promise.try ->
-		if applicationName?
-			return resin.models.device.getAllByApplication(applicationName)
-		return resin.models.device.getAll()
+exports.inferOrSelectDevice = (preferredUuid) ->
+	resin.models.device.getAll()
 	.filter (device) ->
 		device.is_online
-	.then (devices) ->
-		if _.isEmpty(devices)
-			throw new Error('You don\'t have any devices')
+	.then (onlineDevices) ->
+		if _.isEmpty(onlineDevices)
+			throw new Error('You don\'t have any devices online')
 
 		return form.ask
 			message: 'Select a device'
 			type: 'list'
-			choices: _.map devices, (device) ->
+			default: if preferredUuid in _.map(onlineDevices, 'uuid') then preferredUuid else onlineDevices[0].uuid
+			choices: _.map onlineDevices, (device) ->
 				return {
 					name: "#{device.name or 'Untitled'} (#{device.uuid.slice(0, 7)})"
 					value: device.uuid

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "resin-pine": "^1.3.0",
     "resin-sdk": "^5.3.5",
     "resin-settings-client": "^3.5.0",
-    "resin-sync": "^2.0.2",
+    "resin-sync": "^3.0.0",
     "resin-vcs": "^2.0.0",
     "rimraf": "^2.4.3",
     "rindle": "^1.0.0",


### PR DESCRIPTION
## New features
* Automatically **parse '.gitignore'** for file inclusions/exclusions from resin sync by default. Skip parsing with `--skip-gitignore`
* **Automatically save options** to `<sourceDirectory>/.resin-sync.yml` after every run
* Support **user-specified destination directories** with `--destination/-d` option
* Implement `--after` option to perform actions local (e.g. cleanup) after resin sync has finished
* Interactive dialog for destination directory, with `/usr/src/app` being the default choice

## Changes
* `resin sync` **`--source/-s`** option is mandatory if a `.resin-sync.yml` file is not found in the current directory
* `resin sync/ssh` now only accept `uuid` as an argument (`appName` has been deprecated)
* Always display interactive device selection dialog when uuid is not passed as an argument

## Fixes
* Disable ControlMaster ssh option (as reported in support)