### PR TITLE
Upgrade `resin-sdk` to v5.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "resin-device-init": "^2.0.4",
     "resin-image-manager": "^4.0.0",
     "resin-pine": "^1.3.0",
-    "resin-sdk": "^5.3.0",
+    "resin-sdk": "^5.3.5",
     "resin-settings-client": "^3.5.0",
     "resin-sync": "^2.0.2",
     "resin-vcs": "^2.0.0",


### PR DESCRIPTION
This version contains a fix for `undefined` logs. See:

- https://github.com/resin-io/resin-sdk/pull/217
- https://github.com/resin-io/resin-device-logs/pull/14

Fixes: https://github.com/resin-io/resin-cli/issues/370
Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>