### PR TITLE
Attempt to get device type from the image first partition

### DIFF
--- a/build/utils/helpers.js
+++ b/build/utils/helpers.js
@@ -16,7 +16,7 @@ limitations under the License.
  */
 
 (function() {
-  var Promise, _, capitano, chalk, os, president;
+  var Promise, _, capitano, chalk, imagefs, os, president, resin, rindle;
 
   Promise = require('bluebird');
 
@@ -27,6 +27,12 @@ limitations under the License.
   _.str = require('underscore.string');
 
   president = Promise.promisifyAll(require('president'));
+
+  resin = require('resin-sdk');
+
+  imagefs = require('resin-image-fs');
+
+  rindle = require('rindle');
 
   os = require('os');
 
@@ -61,6 +67,18 @@ limitations under the License.
       console.log('Type your computer password to continue');
     }
     return president.executeAsync(command);
+  };
+
+  exports.getManifest = function(image, deviceType) {
+    return imagefs.read({
+      image: image,
+      partition: {
+        primary: 1
+      },
+      path: '/device-type.json'
+    }).then(rindle.extractAsync).then(JSON.parse)["catch"](function() {
+      return resin.models.device.getManifestBySlug(deviceType);
+    });
   };
 
 }).call(this);

--- a/lib/actions/os.coffee
+++ b/lib/actions/os.coffee
@@ -113,9 +113,8 @@ exports.configure =
 		helpers = require('../utils/helpers')
 
 		console.info('Configuring operating system image')
-		resin.models.device.get(params.uuid)
-			.get('device_type')
-			.then(resin.models.device.getManifestBySlug)
+		resin.models.device.get(params.uuid).then (device) ->
+			helpers.getManifest(params.image, device.device_type)
 			.get('options')
 			.then (questions) ->
 
@@ -163,13 +162,13 @@ exports.initialize =
 	action: (params, options, done) ->
 		Promise = require('bluebird')
 		umount = Promise.promisifyAll(require('umount'))
-		resin = require('resin-sdk')
 		form = require('resin-cli-form')
 		init = require('resin-device-init')
 		patterns = require('../utils/patterns')
+		helpers = require('../utils/helpers')
 
 		console.info('Initializing device')
-		resin.models.device.getManifestBySlug(options.type)
+		helpers.getManifest(params.image, options.type)
 			.then (manifest) ->
 				return manifest.initialization?.options
 			.then (questions) ->

--- a/lib/utils/helpers.coffee
+++ b/lib/utils/helpers.coffee
@@ -19,6 +19,9 @@ capitano = Promise.promisifyAll(require('capitano'))
 _ = require('lodash')
 _.str = require('underscore.string')
 president = Promise.promisifyAll(require('president'))
+resin = require('resin-sdk')
+imagefs = require('resin-image-fs')
+rindle = require('rindle')
 os = require('os')
 chalk = require('chalk')
 
@@ -52,3 +55,18 @@ exports.sudo = (command, message) ->
 		console.log('Type your computer password to continue')
 
 	return president.executeAsync(command)
+
+exports.getManifest = (image, deviceType) ->
+
+	# Attempt to read manifest from the first
+	# partition, but fallback to the API if
+	# we encounter any errors along the way.
+	imagefs.read
+		image: image
+		partition:
+			primary: 1
+		path: '/device-type.json'
+	.then(rindle.extractAsync)
+	.then(JSON.parse)
+	.catch ->
+		resin.models.device.getManifestBySlug(deviceType)

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "resin-config-json": "^1.0.0",
     "resin-device-config": "^3.0.0",
     "resin-device-init": "^2.1.0",
+    "resin-image-fs": "^2.1.2",
     "resin-image-manager": "^4.0.0",
     "resin-pine": "^1.3.0",
     "resin-sdk": "^5.3.5",


### PR DESCRIPTION
New images will ship a `device-type.json` file in the first partition,
which we can use instead of querying the API for certain configuration
and initialisation commands.

If the file is not found, or is malformed, we still fallback to the API.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>