### PR TITLE
Fix `Boolean options can't have parameters` error

### DIFF
--- a/build/actions/command-options.js
+++ b/build/actions/command-options.js
@@ -75,7 +75,6 @@ limitations under the License.
 
   exports.forceUpdateLock = {
     signature: 'force',
-    parameter: 'force',
     description: 'force action if the update lock is set',
     boolean: true,
     alias: 'f'

--- a/build/actions/sync.js
+++ b/build/actions/sync.js
@@ -19,7 +19,7 @@ limitations under the License.
   var loadConfig;
 
   loadConfig = function(source) {
-    var _, config, configPath, error, fs, jsYaml, path, result;
+    var _, config, configPath, error, error1, fs, jsYaml, path, result;
     fs = require('fs');
     path = require('path');
     _ = require('lodash');
@@ -105,6 +105,7 @@ limitations under the License.
       resinSync = require('resin-sync');
       patterns = require('../utils/patterns');
       return Promise["try"](function() {
+        var error1;
         try {
           fs.accessSync(path.join(process.cwd(), '.resin-sync.yml'));
         } catch (error1) {

--- a/lib/actions/command-options.coffee
+++ b/lib/actions/command-options.coffee
@@ -64,7 +64,6 @@ exports.wifiKey =
 
 exports.forceUpdateLock =
 	signature: 'force'
-	parameter: 'force'
 	description: 'force action if the update lock is set'
 	boolean: true
 	alias: 'f'


### PR DESCRIPTION
This error was introduced as part of
`9cf42462c029e038e09efc961736946be8bfcb9b`, since the `forceUpdateLock`
option being used in the `reboot` command contains a `parameter`
property despite being declared a boolean.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>