### PR TITLE
Respect source parameter in resin build

### DIFF
--- a/build/actions/deploy.js
+++ b/build/actions/deploy.js
@@ -15,7 +15,7 @@ formatImageName = function(image) {
 };
 
 parseInput = Promise.method(function(params, options) {
-  var appName, context, image;
+  var appName, image, source;
   if (params.appName == null) {
     throw new Error('Need an application to deploy to!');
   }
@@ -28,11 +28,11 @@ parseInput = Promise.method(function(params, options) {
     options.build = false;
     image = params.image;
   } else if (options.build) {
-    context = options.source || '.';
+    source = options.source || '.';
   } else {
     throw new Error('Need either an image or a build flag!');
   }
-  return [appName, options.build, context, image];
+  return [appName, options.build, source, image];
 });
 
 pushProgress = function(imageSize, request, timeout) {
@@ -138,14 +138,14 @@ module.exports = {
     tmp.setGracefulCleanup();
     docker = dockerUtils.getDocker(options);
     return parseInput(params, options).then(function(arg) {
-      var appName, build, context, imageName;
-      appName = arg[0], build = arg[1], context = arg[2], imageName = arg[3];
+      var appName, build, imageName, source;
+      appName = arg[0], build = arg[1], source = arg[2], imageName = arg[3];
       return tmpNameAsync().then(function(tmpPath) {
         options = _.assign({}, options, {
           appName: appName
         });
         params = _.assign({}, params, {
-          context: context
+          source: source
         });
         return Promise["try"](function() {
           if (build) {

--- a/build/utils/docker.js
+++ b/build/utils/docker.js
@@ -94,10 +94,10 @@ exports.runBuild = function(params, options, getBundleInfo) {
   Promise = require('bluebird');
   dockerBuild = require('resin-docker-build');
   resolver = require('resin-bundle-resolve');
-  if (params.context == null) {
-    params.context = '.';
+  if (params.source == null) {
+    params.source = '.';
   }
-  return tarDirectory(params.context).then(function(tarStream) {
+  return tarDirectory(params.source).then(function(tarStream) {
     return new Promise(function(resolve, reject) {
       var builder, connectOpts, hooks, opts;
       hooks = {

--- a/lib/actions/deploy.coffee
+++ b/lib/actions/deploy.coffee
@@ -19,11 +19,11 @@ parseInput = Promise.method (params, options) ->
 		options.build = false
 		image = params.image
 	else if options.build
-		context = options.source || '.'
+		source = options.source || '.'
 	else
 		throw new Error('Need either an image or a build flag!')
 
-	return [appName, options.build, context, image]
+	return [appName, options.build, source, image]
 
 pushProgress = (imageSize, request, timeout = 250) ->
 	process.stdout.write('Initialising...')
@@ -127,13 +127,13 @@ module.exports =
 		docker = dockerUtils.getDocker(options)
 		# Check input parameters
 		parseInput(params, options)
-		.then ([appName, build, context, imageName]) ->
+		.then ([appName, build, source, imageName]) ->
 			tmpNameAsync()
 			.then (tmpPath) ->
 
 				# Setup the build args for how the build routine expects them
 				options = _.assign({}, options, { appName })
-				params = _.assign({}, params, { context })
+				params = _.assign({}, params, { source })
 
 				Promise.try ->
 					if build

--- a/lib/utils/docker.coffee
+++ b/lib/utils/docker.coffee
@@ -107,10 +107,10 @@ exports.runBuild = (params, options, getBundleInfo) ->
 	resolver = require('resin-bundle-resolve')
 
 	# The default build context is the current directory
-	params.context ?= '.'
+	params.source ?= '.'
 
 	# Tar up the directory, ready for the build stream
-	tarDirectory(params.context)
+	tarDirectory(params.source)
 	.then (tarStream) ->
 		new Promise (resolve, reject) ->
 			hooks =


### PR DESCRIPTION
Upon changing the name of the source parameter from `context`, some
places weren't changed, this commit fixes that.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>