### PR TITLE
Fix the not-enough-unicorns bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add uploading of build logs when present with resin deploy
 
+### Fixed
+
+- Fixed the not enough unicorns bug in resin build
+
 ## [5.9.1] - 2017-05-01
 
 ### Fixed

--- a/build/utils/docker.js
+++ b/build/utils/docker.js
@@ -99,11 +99,12 @@ exports.tarDirectory = tarDirectory = function(dir) {
 };
 
 exports.runBuild = function(params, options, getBundleInfo, logStreams) {
-  var Promise, dockerBuild, es, logging, logs, resolver;
+  var Promise, dockerBuild, doodles, es, logging, logs, resolver;
   Promise = require('bluebird');
   dockerBuild = require('resin-docker-build');
   resolver = require('resin-bundle-resolve');
   es = require('event-stream');
+  doodles = require('resin-doodles');
   logging = require('../utils/logging');
   if (params.source == null) {
     params.source = '.';
@@ -117,6 +118,9 @@ exports.runBuild = function(params, options, getBundleInfo, logStreams) {
           if (options.tag != null) {
             console.log("Tagging image as " + options.tag);
           }
+          console.log();
+          console.log(doodles.getDoodle());
+          console.log();
           return resolve({
             image: image,
             log: logs

--- a/lib/utils/docker.coffee
+++ b/lib/utils/docker.coffee
@@ -118,6 +118,7 @@ exports.runBuild = (params, options, getBundleInfo, logStreams) ->
 	dockerBuild = require('resin-docker-build')
 	resolver = require('resin-bundle-resolve')
 	es = require('event-stream')
+	doodles = require('resin-doodles')
 
 	logging = require('../utils/logging')
 
@@ -133,7 +134,14 @@ exports.runBuild = (params, options, getBundleInfo, logStreams) ->
 				buildSuccess: (image) ->
 					if options.tag?
 						console.log("Tagging image as #{options.tag}")
+					# Show charlie. In the interest of cloud parity,
+					# use console.log, not the standard logging streams
+					console.log()
+					console.log(doodles.getDoodle())
+					console.log()
+
 					resolve({ image, log: logs } )
+
 				buildFailure: reject
 				buildStream: (stream) ->
 					getBundleInfo(options)

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "resin-device-config": "^3.0.0",
     "resin-device-init": "^2.2.1",
     "resin-docker-build": "^0.4.0",
+    "resin-doodles": "0.0.1",
     "resin-image-fs": "^2.1.2",
     "resin-image-manager": "^4.1.1",
     "resin-sdk-preconfigured": "^6.0.0",


### PR DESCRIPTION
Add successful build indicator in the form of a unicorn.

Fixes #501
Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>