### PR TITLE
Change update check interval to once a day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Reduce granularity of update checking to one day
 - Include extra usage metadata in error logging to help debugging
 - Add uploading of build logs when present with resin deploy
 - Highlight cache usage in a local build

--- a/build/utils/update.js
+++ b/build/utils/update.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-var isRoot, notifier, packageJSON, updateNotifier;
+var isRoot, notifier, packageJSON, resinUpdateInterval, updateNotifier;
 
 updateNotifier = require('update-notifier');
 
@@ -23,10 +23,12 @@ isRoot = require('is-root');
 
 packageJSON = require('../../package.json');
 
+resinUpdateInterval = 1000 * 60 * 60 * 24 * 1;
+
 if (!isRoot()) {
   notifier = updateNotifier({
     pkg: packageJSON,
-    updateCheckInterval: 0
+    updateCheckInterval: resinUpdateInterval
   });
 }
 

--- a/lib/utils/update.coffee
+++ b/lib/utils/update.coffee
@@ -18,17 +18,17 @@ updateNotifier = require('update-notifier')
 isRoot = require('is-root')
 packageJSON = require('../../package.json')
 
+# Check for an update once a day. 1 day granularity should be
+# enough, rather than every run.
+resinUpdateInterval = 1000 * 60 * 60 * 24 * 1
+
 # `update-notifier` creates files to make the next
 # running time ask for updated, however this can lead
 # to ugly EPERM issues if those files are created as root.
 if not isRoot()
 	notifier = updateNotifier
 		pkg: packageJSON
-
-		# Force update notification alert
-		# to be shown every time there is
-		# an update.
-		updateCheckInterval: 0
+		updateCheckInterval: resinUpdateInterval
 
 exports.hasAvailableUpdate = ->
 	return notifier?


### PR DESCRIPTION
This gives the user enough notice to stay well updated, but won't spam
them if they're using resin-cli frequently.

Connects-to: #485
Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>