### PR TITLE
Include full command line arguments in Sentry errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Include extra usage metadata in error logging to help debugging
 - Add uploading of build logs when present with resin deploy
 - Highlight cache usage in a local build
 - Show a progress bar for upload progress

--- a/build/app.js
+++ b/build/app.js
@@ -29,6 +29,12 @@ Raven.config(require('./config').sentryDsn, {
   return process.exit(1);
 });
 
+Raven.setContext({
+  extra: {
+    args: process.argv
+  }
+});
+
 globalTunnel = require('global-tunnel-ng');
 
 settings = require('resin-settings-client');

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -22,7 +22,7 @@ Raven.config require('./config').sentryDsn,
 .install (logged, error) ->
 	console.error(error)
 	process.exit(1)
-
+Raven.setContext(extra: args: process.argv)
 
 # Doing this before requiring any other modules,
 # including the 'resin-sdk', to prevent any module from reading the http proxy config


### PR DESCRIPTION
Connects to #520 

Nice simple one. Example output: https://sentry.io/resinio/cli/issues/271770204/events/latest/#extra