### PR TITLE
resin build: fix mismatch in command line argument signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Fixed
+
+- Fixed command line arguments for `resin build`
+
 ## [5.10.1] - 2017-05-22
 
 ### Fixed

--- a/build/actions/build.js
+++ b/build/actions/build.js
@@ -31,7 +31,7 @@ module.exports = {
       description: 'The architecture to build for',
       alias: 'A'
     }, {
-      signature: 'devicetype',
+      signature: 'deviceType',
       parameter: 'deviceType',
       description: 'The type of device this build is for',
       alias: 'd'

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1304,7 +1304,7 @@ Examples:
 
 The architecture to build for
 
-#### --devicetype, -d &#60;deviceType&#62;
+#### --deviceType, -d &#60;deviceType&#62;
 
 The type of device this build is for
 

--- a/lib/actions/build.coffee
+++ b/lib/actions/build.coffee
@@ -45,7 +45,7 @@ module.exports =
 			alias: 'A'
 		},
 		{
-			signature: 'devicetype'
+			signature: 'deviceType'
 			parameter: 'deviceType'
 			description: 'The type of device this build is for'
 			alias: 'd'


### PR DESCRIPTION
The command line arg was taking `devicetype`, but the rest of the code
uses `deviceType`. Thus it was impossible to specify a device type
in practice to build a `Dockerfile.template`.

Change-type: patch
Signed-off-by: Gergely Imreh <imrehg@gmail.com>