### PR TITLE
Resin deploy ux improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `package-lock.json` for `npm5` users
 - Added ability to run an emulated build silently with `resin build`
 - Gzip images when uploading in `resin deploy`
+- Show a clear message immediately as the deploy starts, if we're deploying an image.
 
 ### Fixed
 

--- a/build/actions/deploy.js
+++ b/build/actions/deploy.js
@@ -226,6 +226,7 @@ module.exports = {
           }).then(function(arg1) {
             var buildLogs, imageName;
             imageName = arg1.image, buildLogs = arg1.log;
+            logging.logInfo(logStreams, 'Initializing deploy...');
             logs = buildLogs;
             return Promise.all([dockerUtils.bufferImage(docker, imageName, bufferFile), token, username, url, params.appName, logStreams]).spread(performUpload);
           })["finally"](function() {

--- a/build/actions/deploy.js
+++ b/build/actions/deploy.js
@@ -171,8 +171,8 @@ uploadToPromise = function(uploadRequest, logStreams) {
 
 module.exports = {
   signature: 'deploy <appName> [image]',
-  description: 'Deploy a container to a resin.io application',
-  help: 'Use this command to deploy and optionally build an image to an application.\n\nUsage: deploy <appName> ([image] | --build [--source build-dir])\n\nNote: If building with this command, all options supported by `resin build`\nare also supported with this command.\n\nExamples:\n	$ resin deploy myApp --build --source myBuildDir/\n	$ resin deploy myApp myApp/myImage',
+  description: 'Deploy an image to a resin.io application',
+  help: 'Use this command to deploy an image to an application, optionally building it first.\n\nUsage: deploy <appName> ([image] | --build [--source build-dir])\n\nNote: If building with this command, all options supported by `resin build`\nare also supported with this command.\n\nExamples:\n	$ resin deploy myApp --build --source myBuildDir/\n	$ resin deploy myApp myApp/myImage',
   permission: 'user',
   options: dockerUtils.appendOptions([
     {

--- a/build/actions/deploy.js
+++ b/build/actions/deploy.js
@@ -229,7 +229,9 @@ module.exports = {
             logs = buildLogs;
             return Promise.all([dockerUtils.bufferImage(docker, imageName, bufferFile), token, username, url, params.appName, logStreams]).spread(performUpload);
           })["finally"](function() {
-            return require('mz/fs').unlink(bufferFile)["catch"](_.noop);
+            return Promise["try"](function() {
+              return require('mz/fs').unlink(bufferFile);
+            })["catch"](_.noop);
           });
         });
       }).tap(function(arg) {

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1354,7 +1354,7 @@ Run an emulated build using Qemu
 
 ## deploy &#60;appName&#62; [image]
 
-Use this command to deploy and optionally build an image to an application.
+Use this command to deploy an image to an application, optionally building it first.
 
 Usage: deploy <appName> ([image] | --build [--source build-dir])
 

--- a/lib/actions/deploy.coffee
+++ b/lib/actions/deploy.coffee
@@ -206,7 +206,8 @@ module.exports =
 						# If the file was never written to (for instance because an error
 						# has occured before any data was written) this call will throw an
 						# ugly error, just suppress it
-						require('mz/fs').unlink(bufferFile)
+						Promise.try ->
+							require('mz/fs').unlink(bufferFile)
 						.catch(_.noop)
 			.tap ({ image: imageName, buildId }) ->
 				logging.logSuccess(logStreams, "Successfully deployed image: #{formatImageName(imageName)}")

--- a/lib/actions/deploy.coffee
+++ b/lib/actions/deploy.coffee
@@ -126,9 +126,9 @@ uploadToPromise = (uploadRequest, logStreams) ->
 
 module.exports =
 	signature: 'deploy <appName> [image]'
-	description: 'Deploy a container to a resin.io application'
+	description: 'Deploy an image to a resin.io application'
 	help: '''
-		Use this command to deploy and optionally build an image to an application.
+		Use this command to deploy an image to an application, optionally building it first.
 
 		Usage: deploy <appName> ([image] | --build [--source build-dir])
 

--- a/lib/actions/deploy.coffee
+++ b/lib/actions/deploy.coffee
@@ -192,6 +192,8 @@ module.exports =
 						else
 							{ image: imageName, log: '' }
 					.then ({ image: imageName, log: buildLogs }) ->
+						logging.logInfo(logStreams, 'Initializing deploy...')
+
 						logs = buildLogs
 						Promise.all [
 							dockerUtils.bufferImage(docker, imageName, bufferFile)


### PR DESCRIPTION
A couple of other small changes I noticed along the way with the deploy gzipping stuff, pulled out as a separate PR. This PR:

* Shows the correct error if a build fails (instead of 'could not delete `bufferFile`', which happened before, because the `finally` step fails in that case)
* Shows an 'Initializing deploy...' message after the build, so you can tell what's going on during the couple of seconds gap while we get the docker image and buffer it to disk.
* Tweaks the docs slightly for clarity (mainly to be consistent about deploying _images_, not containers)