### PR TITLE
Read ca files and convert to string before passing to the docker daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Fixed
+
+- Ensure to send .pem file contents rather than filename to docker daemon
+
 ## [5.11.0] - 2017-06-19
 
 ### Added


### PR DESCRIPTION
Before this commit, the docker daemon would recieve the filename of the
.pem files, which would be interpreted as the body and would fail. This
commit ensures that the actual body of the pem files are sent to the
daemon.

cc @imrehg 

Change-type: patch
Connects-to: #562
Signed-off-by: Cameron Diver <cameron@resin.io>