### PR TITLE
Bump resin-sync@8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Bump resin-sync@8.0.0
+	- Permit resin sync to collaborators
 - Do not explicitly disable ControlMaster option for device SSH connections
 - Fix issue when using resin deploy with non-standard stdin (e.g. git bash on windows)
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "resin-sdk-preconfigured": "^6.4.1",
     "resin-settings-client": "^3.6.1",
     "resin-stream-logger": "^0.0.4",
-    "resin-sync": "^7.0.0",
+    "resin-sync": "^8.0.0",
     "rimraf": "^2.4.3",
     "rindle": "^1.0.0",
     "semver": "^5.3.0",


### PR DESCRIPTION
- resin sync: do not explicitly disable ControlMaster SSH option
- resin sync: whitelist collaborators

fixes #422
change-type: minor

**Note:** similar to #569 , this depends on the resin-proxy backend being deployed first