### PR TITLE
Add a polyfill to fix local configure in older (<6) Node versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Fixed
 
 - Ensure to send .pem file contents rather than filename to docker daemon
+- Add a polyfill to fix `local configure` in older (<6) Node versions
 
 ## [5.11.0] - 2017-06-19
 

--- a/build/app.js
+++ b/build/app.js
@@ -35,6 +35,8 @@ Raven.setContext({
   }
 });
 
+require('buffer-v6-polyfill');
+
 globalTunnel = require('global-tunnel-ng');
 
 settings = require('resin-settings-client');

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -24,6 +24,8 @@ Raven.config require('./config').sentryDsn,
 	process.exit(1)
 Raven.setContext(extra: args: process.argv)
 
+require('buffer-v6-polyfill')
+
 # Doing this before requiring any other modules,
 # including the 'resin-sdk', to prevent any module from reading the http proxy config
 # before us

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-register": "^6.16.3",
     "bash": "0.0.1",
     "bluebird": "^3.3.3",
+    "buffer-v6-polyfill": "^1.0.3",
     "capitano": "^1.7.0",
     "chalk": "^1.1.3",
     "coffee-script": "^1.12.6",


### PR DESCRIPTION
Connects to #566 

This should be pretty much the final change of the 5.X line, and then we're going to drop <6 support entirely.