### PR TITLE
Remove Buffer polyfill, require Node v6+, and print warnings in older versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Fixed
+
+- **Breaking** Remove Buffer polyfill, require Node v6+, and print warnings in older versions
+
 ## [5.11.1] - 2017-06-22
 
 ## Added

--- a/build/app.js
+++ b/build/app.js
@@ -15,7 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-var Promise, Raven, _, actions, capitano, capitanoExecuteAsync, errors, events, globalTunnel, plugins, proxy, resin, settings, update;
+var Promise, Raven, _, actions, capitano, capitanoExecuteAsync, errors, events, globalTunnel, plugins, proxy, resin, settings, update, validNodeVersions;
 
 Raven = require('raven');
 
@@ -36,7 +36,11 @@ Raven.setContext({
   }
 });
 
-require('buffer-v6-polyfill');
+validNodeVersions = require('../package.json').engines.node;
+
+if (!require('semver').satisfies(process.version, validNodeVersions)) {
+  console.warn("Warning: this version of Node does not match the requirements of this package. This package expects " + validNodeVersions + ", but you're using " + process.version + ". This may cause unexpected behaviour.");
+}
 
 globalTunnel = require('global-tunnel-ng');
 

--- a/build/app.js
+++ b/build/app.js
@@ -39,7 +39,7 @@ Raven.setContext({
 validNodeVersions = require('../package.json').engines.node;
 
 if (!require('semver').satisfies(process.version, validNodeVersions)) {
-  console.warn("Warning: this version of Node does not match the requirements of this package. This package expects " + validNodeVersions + ", but you're using " + process.version + ". This may cause unexpected behaviour.");
+  console.warn("Warning: this version of Node does not match the requirements of this package.\nThis package expects " + validNodeVersions + ", but you're using " + process.version + ".\nThis may cause unexpected behaviour.");
 }
 
 globalTunnel = require('global-tunnel-ng');

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -29,9 +29,11 @@ Raven.setContext
 
 validNodeVersions = require('../package.json').engines.node
 if not require('semver').satisfies(process.version, validNodeVersions)
-	console.warn("Warning: this version of Node does not match the requirements of this package.
+	console.warn """
+	Warning: this version of Node does not match the requirements of this package.
 	This package expects #{validNodeVersions}, but you're using #{process.version}.
-	This may cause unexpected behaviour.")
+	This may cause unexpected behaviour.
+	"""
 
 
 # Doing this before requiring any other modules,

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -27,7 +27,12 @@ Raven.setContext
 		args: process.argv
 		node_version: process.version
 
-require('buffer-v6-polyfill')
+validNodeVersions = require('../package.json').engines.node
+if not require('semver').satisfies(process.version, validNodeVersions)
+	console.warn("Warning: this version of Node does not match the requirements of this package.
+	This package expects #{validNodeVersions}, but you're using #{process.version}.
+	This may cause unexpected behaviour.")
+
 
 # Doing this before requiring any other modules,
 # including the 'resin-sdk', to prevent any module from reading the http proxy config

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   ],
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=6.0"
+  },
   "devDependencies": {
     "ent": "^2.2.0",
     "gulp": "^3.9.0",
@@ -40,7 +43,6 @@
     "babel-register": "^6.16.3",
     "bash": "0.0.1",
     "bluebird": "^3.3.3",
-    "buffer-v6-polyfill": "^1.0.3",
     "capitano": "^1.7.0",
     "chalk": "^1.1.3",
     "coffee-script": "^1.12.6",
@@ -86,6 +88,7 @@
     "resin-sync": "^7.0.0",
     "rimraf": "^2.4.3",
     "rindle": "^1.0.0",
+    "semver": "^5.3.0",
     "stream-to-promise": "^2.2.0",
     "tmp": "0.0.31",
     "umount": "^1.1.6",


### PR DESCRIPTION
Connects to #567 