### PR TITLE
Upgrade resin-sync to fix node 8 bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Bump resin-sync@8.0.0
+- Bump resin-sync@8.0.1
 	- Permit resin sync to collaborators
+	- Fix "'cwd' must be a string" error in Node 8
 - Do not explicitly disable ControlMaster option for device SSH connections
 
 ## [6.0.0] - 2017-06-26

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "resin-sdk-preconfigured": "^6.4.1",
     "resin-settings-client": "^3.6.1",
     "resin-stream-logger": "^0.0.4",
-    "resin-sync": "^8.0.0",
+    "resin-sync": "^8.0.1",
     "rimraf": "^2.4.3",
     "rindle": "^1.0.0",
     "semver": "^5.3.0",


### PR DESCRIPTION
Brings in https://github.com/resin-io-modules/resin-sync/pull/131 from resin-sync.

Connects-To: #543
Change-Type: patch