### PR TITLE
Help users using old node versions to upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Added a link to the Node download page in the warning for users with old Node versions
 
 ## [6.3.1] - 2017-08-08
 

--- a/build/app.js
+++ b/build/app.js
@@ -39,7 +39,7 @@ Raven.setContext({
 validNodeVersions = require('../package.json').engines.node;
 
 if (!require('semver').satisfies(process.version, validNodeVersions)) {
-  console.warn("Warning: this version of Node does not match the requirements of this package.\nThis package expects " + validNodeVersions + ", but you're using " + process.version + ".\nThis may cause unexpected behaviour.");
+  console.warn("Warning: this version of Node does not match the requirements of this package.\nThis package expects " + validNodeVersions + ", but you're using " + process.version + ".\nThis may cause unexpected behaviour.\n\nTo upgrade your Node, visit https://nodejs.org/en/download/\n");
 }
 
 globalTunnel = require('global-tunnel-ng');

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -33,6 +33,9 @@ if not require('semver').satisfies(process.version, validNodeVersions)
 	Warning: this version of Node does not match the requirements of this package.
 	This package expects #{validNodeVersions}, but you're using #{process.version}.
 	This may cause unexpected behaviour.
+
+	To upgrade your Node, visit https://nodejs.org/en/download/
+
 	"""
 
 


### PR DESCRIPTION
Quick fix for #603, just to quickly clean that one up. Output looks like:

```bash
> resin help
Warning: this version of Node does not match the requirements of this package.
This package expects >=6.0, but you're using v4.8.3.
This may cause unexpected behaviour.

To upgrade your Node, visit https://nodejs.org/en/download/

Usage: resin [COMMAND] [OPTIONS]

If you need help, or just want to say hi, don't hesitate in reaching out at:

  GitHub: https://github.com/resin-io/resin-cli/issues/new
  Forums: https://forums.resin.io

[...]
```