### PR TITLE
Remove inconsistent (and now unneccesary) 'Tagging image as' message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Provide a helpful warning when Docker is not installed (or is unaccessible)
 - Added a link to the Node download page in the warning for users with old Node versions
+- Remove inconsistent (and now unneccesary) 'Tagging image as' message from local build output
 
 ## [6.3.1] - 2017-08-08
 

--- a/build/utils/docker.js
+++ b/build/utils/docker.js
@@ -207,9 +207,6 @@ exports.runBuild = function(params, options, getBundleInfo, logger) {
       hooks = {
         buildSuccess: function(image) {
           var doodle;
-          if (options.tag != null) {
-            console.log("Tagging image as " + options.tag);
-          }
           doodle = doodles.getDoodle();
           console.log();
           console.log(doodle);

--- a/lib/utils/docker.coffee
+++ b/lib/utils/docker.coffee
@@ -209,8 +209,6 @@ exports.runBuild = (params, options, getBundleInfo, logger) ->
 		new Promise (resolve, reject) ->
 			hooks =
 				buildSuccess: (image) ->
-					if options.tag?
-						console.log("Tagging image as #{options.tag}")
 					# Show charlie. In the interest of cloud parity,
 					# use console.log, not the standard logging streams
 					doodle = doodles.getDoodle()


### PR DESCRIPTION
Fixes #612 