### PR TITLE
Use forked global-scoket-ng that doesn't proxy connection to socket files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Use forked global-tunnel-ng that doesn't proxy connections to socket files
 - Preload support
 
 ## [6.4.0] - 2017-08-11

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "dockerode": "^2.5.0",
     "drivelist": "^5.0.22",
     "etcher-image-write": "^9.0.3",
-    "global-tunnel-ng": "^2.1.0",
+    "global-tunnel-ng": "github:zvin/global-tunnel#dont-proxy-connections-to-file-sockets",
     "hasbin": "^1.2.3",
     "inquirer": "^3.1.1",
     "is-root": "^1.0.0",


### PR DESCRIPTION
This is temporary, until https://github.com/np-maintain/global-tunnel/pull/9 is merged.

Connects to #618

Change-Type: patch