### PR TITLE
Remove unused babel dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "@resin.io/valid-email": "^0.1.0",
     "ansi-escapes": "^2.0.0",
     "any-promise": "^1.3.0",
-    "babel-preset-es2015": "^6.16.0",
-    "babel-register": "^6.16.3",
     "bash": "0.0.1",
     "bluebird": "^3.3.3",
     "capitano": "^1.7.0",


### PR DESCRIPTION
Another part of #622, just because it's an easy way to shave 10MB or so off the CLI install.

Seems that @CameronDiver put these in as part of the local build/deploy work (#466), but they don't look used and neither he nor I know any good reason why they should be here. Some very brief testing suggests everything works without them very happily - unless you know something we don't @emirotin we should drop these.