### PR TITLE
Set up Travis npm autopublish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: node_js
+matrix:
+  include:
+  - node_js:
+    - '6'
+    env:
+    - CAN_DEPLOY=true
+before_install:
+- npm -g install npm
+script: echo 'TODO Write some tests'
+notifications:
+  email: false
+deploy:
+  provider: npm
+  email: accounts@resin.io
+  api_key:
+    secure: phet6Du13hc1bzStbmpwy2ODNL5BFwjAmnpJ5wMcbWfI7fl0OtQ61s2+vW5hJAvm9fiRLOfiGAEiqOOtoupShZ1X8BNkC708d8+V+iZMoFh3+j6wAEz+N1sVq471PywlOuLAscOcqQNp92giCVt+4VPx2WQYh06nLsunvysGmUM=
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: "$CAN_DEPLOY = 'true' && $TRAVIS_TAG =~ ^v?[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+"
+    repo: resin-io/resin-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Set up Travis npm autodeploy
 - Upgrade to Lodash v4, drastically reducing install size (due to dedupes)
 - Updated npm package description
 - Added support for looking up shared apps via [owner]/[appname] strings


### PR DESCRIPTION
Set up autodeploy (this is a somewhat-simplified version of the SDK autodeploy config)

With this merged, pushing a commit tagged with a version number will trigger an npm publish of the tagged code (but you'll still need to manually manage the package.json version and changelog). Once versionbot is in place, a versionbot merge will trigger this.

Connects to #564