### PR TITLE
Separate multicontainer package

### DIFF
--- a/bin/resin-mc
+++ b/bin/resin-mc
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+var hidepath = require('hidepath');
+var userHome = require('home-or-tmp');
+var path = require('path');
+
+process.env.RESINRC_RESIN_URL = process.env.RESINRC_RESIN_URL || 'multi.resinstaging.io'
+process.env.RESINRC_DATA_DIRECTORY = process.env.RESINRC_DATA_DIRECTORY || path.join(userHome, hidepath('resin-mc'))
+
+require('../build/app');

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1427,11 +1427,18 @@ name of container to stop
 
 ## build [source]
 
-Use this command to build a container with a provided docker daemon.
+Use this command to build an image or a complete multi-container project
+with the provided docker daemon.
 
 You must provide either an application or a device-type/architecture
 pair to use the resin Dockerfile pre-processor
 (e.g. Dockerfile.template -> Dockerfile).
+
+This command will look into the given source directory (or the current working
+directory if one isn't specified) for a compose file. If one is found, this
+command will build each service defined in the compose file. If a compose file
+isn't found, the command will look for a Dockerfile, and if yet that isn't found,
+it will try to generate one.
 
 Examples:
 
@@ -1456,6 +1463,18 @@ The type of device this build is for
 
 The target resin.io application this build is for
 
+#### --projectName, -n &#60;projectName&#62;
+
+Specify an alternate project name; default is the directory name
+
+#### --emulated, -e
+
+Run an emulated build using Qemu
+
+#### --inlinelogs
+
+Display all log output from builds inline as a stream
+
 #### --docker, -P &#60;docker&#62;
 
 Path to a local docker socket
@@ -1492,19 +1511,23 @@ Set a build-time variable (eg. "-B 'ARG=value'"). Can be specified multiple time
 
 Don't use docker layer caching when building
 
-#### --emulated, -e
-
-Run an emulated build using Qemu
-
 #### --squash
 
 Squash newly built layers into a single new layer
 
 ## deploy &#60;appName&#62; [image]
 
-Use this command to deploy an image to an application, optionally building it first.
+Use this command to deploy an image or a complete multi-container project
+to an application, optionally building it first.
 
 Usage: `deploy <appName> ([image] | --build [--source build-dir])`
+
+Unless an image is specified, this command will look into the current directory
+(or the one specified by --source) for a compose file. If one is found, this
+command will deploy each service defined in the compose file, building it first
+if an image for it doesn't exist. If a compose file isn't found, the command
+will look for a Dockerfile, and if yet that isn't found, it will try to
+generate one.
 
 To deploy to an app on which you're a collaborator, use
 `resin deploy <appOwnerUsername>/<appName>`.
@@ -1513,6 +1536,8 @@ Note: If building with this command, all options supported by `resin build`
 are also supported with this command.
 
 Examples:
+
+	$ resin deploy myApp
 	$ resin deploy myApp --build --source myBuildDir/
 	$ resin deploy myApp myApp/myImage
 
@@ -1520,15 +1545,27 @@ Examples:
 
 #### --build, -b
 
-Build image then deploy
-
-#### --source, -s &#60;source&#62;
-
-The source directory to use when building the image
+Force a rebuild before deploy
 
 #### --nologupload
 
 Don't upload build logs to the dashboard with image (if building)
+
+#### --projectName, -n &#60;projectName&#62;
+
+Specify an alternate project name; default is the directory name
+
+#### --source, -s &#60;source&#62;
+
+Specify an alternate project directory; default is the working directory
+
+#### --emulated, -e
+
+Run an emulated build using Qemu
+
+#### --inlinelogs
+
+Display all log output from builds inline as a stream
 
 #### --docker, -P &#60;docker&#62;
 
@@ -1565,10 +1602,6 @@ Set a build-time variable (eg. "-B 'ARG=value'"). Can be specified multiple time
 #### --nocache
 
 Don't use docker layer caching when building
-
-#### --emulated, -e
-
-Run an emulated build using Qemu
 
 #### --squash
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "resin-cli-mc",
   "version": "6.10.2",
-  "description": "The official resin.io CLI tool",
+  "description": "The official resin.io CLI tool, for our pre-release multicontainer environment",
   "main": "./build/actions/index.js",
   "homepage": "https://github.com/resin-io/resin-cli",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "resin-cli",
+  "name": "resin-cli-mc",
   "version": "6.10.2",
   "description": "The official resin.io CLI tool",
   "main": "./build/actions/index.js",
@@ -16,7 +16,7 @@
     "lib/"
   ],
   "bin": {
-    "resin": "./bin/resin"
+    "resin-mc": "./bin/resin-mc"
   },
   "scripts": {
     "build": "gulp build && tsc && npm run doc",
@@ -75,6 +75,8 @@
     "express": "^4.13.3",
     "global-tunnel-ng": "github:zvin/global-tunnel#dont-proxy-connections-to-file-sockets",
     "hasbin": "^1.2.3",
+    "hidepath": "^1.0.1",
+    "home-or-tmp": "^3.0.0",
     "humanize": "0.0.9",
     "inquirer": "^3.1.1",
     "is-root": "^1.0.0",


### PR DESCRIPTION
Fixes #741, and also rebuilds the docs (since they haven't been updated, and I needed to build to test) en route.

**We need to be careful _not_ to use versionbot to publish anything using this until we're on master, and to always publish manually instead** (which I expect will work fine in the short-term)

It wouldn't cause a big problem on this branch as things stand right now, but if you rebase over master, then any tagged pushes (e.g. via versionbot) will trigger a build & release of standalone build versions, which get published to github releases. We could do more complex things to fix that, but I don't think there's an easy solution there other than pull all that code back out entirely on this branch (I'd rather not) or separately namespacing with a fully forked repo. Seems easier to just skip versionbot until this is all ready.

Probably more we could do here, like updating the readme and docs, and all the internal help strings, to change all references to `resin` everywhere, but I'm going to assume this is enough for now.