### PR TITLE
Fix uuid params being parsed a numbers

### DIFF
--- a/lib/actions/index.coffee
+++ b/lib/actions/index.coffee
@@ -14,23 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ###
 
+{ normalizeCommands } = require('../utils/normalization')
+
 module.exports =
 	wizard: require('./wizard')
 	app: require('./app')
 	info: require('./info')
 	auth: require('./auth')
-	device: require('./device')
-	env: require('./environment-variables')
+	device: normalizeCommands(require('./device'))
+	env: normalizeCommands(require('./environment-variables'))
 	keys: require('./keys')
-	logs: require('./logs')
+	logs: normalizeCommands(require('./logs'))
 	local: require('./local')
-	notes: require('./notes')
+	notes: normalizeCommands(require('./notes'))
 	help: require('./help')
-	os: require('./os')
+	os: normalizeCommands(require('./os'))
 	settings: require('./settings')
-	config: require('./config')
+	config: normalizeCommands(require('./config'))
 	sync: require('./sync')
-	ssh: require('./ssh')
+	ssh: normalizeCommands(require('./ssh'))
 	internal: require('./internal')
 	build: require('./build')
 	deploy: require('./deploy')

--- a/lib/utils/normalization.ts
+++ b/lib/utils/normalization.ts
@@ -1,0 +1,43 @@
+/*
+Copyright 2016-2018 Resin.io
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import _ = require('lodash');
+
+export function normalizeCommands(commands: {
+	[key: string]: { action?: () => any };
+}) {
+	_.forEach(commands, normalizeActionParams);
+	return commands;
+}
+
+export function normalizeActionParams(commandDefinition: {
+	action?: () => any;
+}) {
+	const action = commandDefinition.action;
+	if (_.isFunction(action)) {
+		commandDefinition.action = function() {
+			const [params, options] = _.toArray(arguments);
+
+			if (_.isNumber(params.uuid)) params.uuid = _.toString(params.uuid);
+
+			// in some methods this is a boolean
+			if (_.isNumber(options.device))
+				options.device = _.toString(options.device);
+
+			action.apply(this, arguments);
+		};
+	}
+}


### PR DESCRIPTION
Normalizes the uuid/device params/options by wrapping the exported actions in a normalization method.

Connects-To: #489
Change-Type: patch
---- Autogenerated Waffleboard Connection: Connects to #489