### PR TITLE
Adding list of nested commands on 'help' command

### DIFF
--- a/lib/actions/help.coffee
+++ b/lib/actions/help.coffee
@@ -91,7 +91,23 @@ command = (params, options, done) ->
 			console.log('\nOptions:\n')
 			print(parse(command.options))
 
+		if params.command
+			listNested(params.command, command.signature)
+
 		return done()
+
+listNested = (commandName) ->
+	list = []
+
+	for command in global._capitano.state.commands
+		parameters = command?.signature?.parameters
+		parameterName = parameters?[0].parameter
+
+		if parameterName is commandName and not (/[^a-z]{1,}/g).test(parameters?[1])
+			list.push("#{parameters?[1]?.parameter}")
+
+	if list.length
+		console.log("also available for '#{commandName}':", list.join(', '))
 
 exports.help =
 	signature: 'help [command...]'

--- a/lib/app.coffee
+++ b/lib/app.coffee
@@ -209,6 +209,9 @@ capitano.command(actions.deploy)
 update.notify()
 
 cli = capitano.parse(process.argv)
+
+global._capitano = capitano
+
 runCommand = ->
 	if cli.global?.help
 		capitanoExecuteAsync(command: "help #{cli.command ? ''}")


### PR DESCRIPTION
Solves #694 

<img width="705" alt="screen shot 2018-03-18 at 8 08 34 pm" src="https://user-images.githubusercontent.com/2047941/37572316-003477de-2ae8-11e8-8e4f-6868d54575fb.png">

- Exposing capitano instance on global through _capitano variable
- Adding method to list all nested commands if available on the help
command