### PR TITLE
Don't include anchor tags in docs, as it breaks the docs site

### DIFF
--- a/automation/capitanodoc/markdown.ts
+++ b/automation/capitanodoc/markdown.ts
@@ -4,9 +4,7 @@ import * as utils from './utils';
 import { Document, Category, Command } from './doc-types';
 
 export function renderCommand(command: Command) {
-	let result = `## <a name="${getAnchor(command)}"></a>${ent.encode(
-		command.signature,
-	)}\n\n${command.help}\n`;
+	let result = `## ${ent.encode(command.signature)}\n\n${command.help}\n`;
 
 	if (!_.isEmpty(command.options)) {
 		result += '\n### Options';
@@ -43,7 +41,6 @@ function getAnchor(command: Command) {
 			.replace(/\[/g, '-')
 			.replace(/\]/g, '-')
 			.replace(/--/g, '-')
-			.replace(/-$/, '')
 			.replace(/\.\.\./g, '')
 			.replace(/\|/g, '')
 			.toLowerCase()

--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -64,11 +64,11 @@ environment variable (in the same standard URL format).
 
 - Application
 
-	- [app create &#60;name&#62;](#app-create-name)
+	- [app create &#60;name&#62;](#app-create-name-)
 	- [apps](#apps)
-	- [app &#60;name&#62;](#app-name)
-	- [app restart &#60;name&#62;](#app-restart-name)
-	- [app rm &#60;name&#62;](#app-rm-name)
+	- [app &#60;name&#62;](#app-name-)
+	- [app restart &#60;name&#62;](#app-restart-name-)
+	- [app rm &#60;name&#62;](#app-rm-name-)
 
 - Authentication
 
@@ -80,31 +80,31 @@ environment variable (in the same standard URL format).
 - Device
 
 	- [devices](#devices)
-	- [device &#60;uuid&#62;](#device-uuid)
+	- [device &#60;uuid&#62;](#device-uuid-)
 	- [devices supported](#devices-supported)
-	- [device register &#60;application&#62;](#device-register-application)
-	- [device rm &#60;uuid&#62;](#device-rm-uuid)
-	- [device identify &#60;uuid&#62;](#device-identify-uuid)
-	- [device reboot &#60;uuid&#62;](#device-reboot-uuid)
-	- [device shutdown &#60;uuid&#62;](#device-shutdown-uuid)
-	- [device public-url enable &#60;uuid&#62;](#device-public-url-enable-uuid)
-	- [device public-url disable &#60;uuid&#62;](#device-public-url-disable-uuid)
-	- [device public-url &#60;uuid&#62;](#device-public-url-uuid)
-	- [device public-url status &#60;uuid&#62;](#device-public-url-status-uuid)
-	- [device rename &#60;uuid&#62; [newName]](#device-rename-uuid--newname)
-	- [device move &#60;uuid&#62;](#device-move-uuid)
+	- [device register &#60;application&#62;](#device-register-application-)
+	- [device rm &#60;uuid&#62;](#device-rm-uuid-)
+	- [device identify &#60;uuid&#62;](#device-identify-uuid-)
+	- [device reboot &#60;uuid&#62;](#device-reboot-uuid-)
+	- [device shutdown &#60;uuid&#62;](#device-shutdown-uuid-)
+	- [device public-url enable &#60;uuid&#62;](#device-public-url-enable-uuid-)
+	- [device public-url disable &#60;uuid&#62;](#device-public-url-disable-uuid-)
+	- [device public-url &#60;uuid&#62;](#device-public-url-uuid-)
+	- [device public-url status &#60;uuid&#62;](#device-public-url-status-uuid-)
+	- [device rename &#60;uuid&#62; [newName]](#device-rename-uuid--newname-)
+	- [device move &#60;uuid&#62;](#device-move-uuid-)
 	- [device init](#device-init)
 
 - Environment Variables
 
 	- [envs](#envs)
-	- [env rm &#60;id&#62;](#env-rm-id)
-	- [env add &#60;key&#62; [value]](#env-add-key--value)
-	- [env rename &#60;id&#62; &#60;value&#62;](#env-rename-id--value)
+	- [env rm &#60;id&#62;](#env-rm-id-)
+	- [env add &#60;key&#62; [value]](#env-add-key--value-)
+	- [env rename &#60;id&#62; &#60;value&#62;](#env-rename-id--value-)
 
 - Help
 
-	- [help [command...]](#help-command)
+	- [help [command...]](#help-command-)
 
 - Information
 
@@ -113,45 +113,45 @@ environment variable (in the same standard URL format).
 - Keys
 
 	- [keys](#keys)
-	- [key &#60;id&#62;](#key-id)
-	- [key rm &#60;id&#62;](#key-rm-id)
-	- [key add &#60;name&#62; [path]](#key-add-name--path)
+	- [key &#60;id&#62;](#key-id-)
+	- [key rm &#60;id&#62;](#key-rm-id-)
+	- [key add &#60;name&#62; [path]](#key-add-name--path-)
 
 - Logs
 
-	- [logs &#60;uuid&#62;](#logs-uuid)
+	- [logs &#60;uuid&#62;](#logs-uuid-)
 
 - Sync
 
-	- [sync [uuid]](#sync-uuid)
+	- [sync [uuid]](#sync-uuid-)
 
 - SSH
 
-	- [ssh [uuid]](#ssh-uuid)
+	- [ssh [uuid]](#ssh-uuid-)
 
 - Notes
 
-	- [note &#60;|note&#62;](#note-note)
+	- [note &#60;|note&#62;](#note-note-)
 
 - OS
 
-	- [os versions &#60;type&#62;](#os-versions-type)
-	- [os download &#60;type&#62;](#os-download-type)
-	- [os build-config &#60;image&#62; &#60;device-type&#62;](#os-build-config-image--device-type)
-	- [os configure &#60;image&#62; [uuid] [deviceApiKey]](#os-configure-image--uuid--deviceapikey)
-	- [os initialize &#60;image&#62;](#os-initialize-image)
+	- [os versions &#60;type&#62;](#os-versions-type-)
+	- [os download &#60;type&#62;](#os-download-type-)
+	- [os build-config &#60;image&#62; &#60;device-type&#62;](#os-build-config-image--device-type-)
+	- [os configure &#60;image&#62; [uuid] [deviceApiKey]](#os-configure-image--uuid--deviceapikey-)
+	- [os initialize &#60;image&#62;](#os-initialize-image-)
 
 - Config
 
 	- [config read](#config-read)
-	- [config write &#60;key&#62; &#60;value&#62;](#config-write-key--value)
-	- [config inject &#60;file&#62;](#config-inject-file)
+	- [config write &#60;key&#62; &#60;value&#62;](#config-write-key--value-)
+	- [config inject &#60;file&#62;](#config-inject-file-)
 	- [config reconfigure](#config-reconfigure)
 	- [config generate](#config-generate)
 
 - Preload
 
-	- [preload &#60;image&#62;](#preload-image)
+	- [preload &#60;image&#62;](#preload-image-)
 
 - Settings
 
@@ -159,22 +159,22 @@ environment variable (in the same standard URL format).
 
 - Wizard
 
-	- [quickstart [name]](#quickstart-name)
+	- [quickstart [name]](#quickstart-name-)
 
 - Local
 
-	- [local configure &#60;target&#62;](#local-configure-target)
-	- [local flash &#60;image&#62;](#local-flash-image)
-	- [local logs [deviceIp]](#local-logs-deviceip)
+	- [local configure &#60;target&#62;](#local-configure-target-)
+	- [local flash &#60;image&#62;](#local-flash-image-)
+	- [local logs [deviceIp]](#local-logs-deviceip-)
 	- [local scan](#local-scan)
-	- [local ssh [deviceIp]](#local-ssh-deviceip)
-	- [local push [deviceIp]](#local-push-deviceip)
-	- [local stop [deviceIp]](#local-stop-deviceip)
+	- [local ssh [deviceIp]](#local-ssh-deviceip-)
+	- [local push [deviceIp]](#local-push-deviceip-)
+	- [local stop [deviceIp]](#local-stop-deviceip-)
 
 - Deploy
 
-	- [build [source]](#build-source)
-	- [deploy &#60;appName&#62; [image]](#deploy-appname--image)
+	- [build [source]](#build-source-)
+	- [deploy &#60;appName&#62; [image]](#deploy-appname--image-)
 
 - Utilities
 
@@ -182,7 +182,7 @@ environment variable (in the same standard URL format).
 
 # Application
 
-## <a name="#app-create-name"></a>app create &#60;name&#62;
+## app create &#60;name&#62;
 
 Use this command to create a new resin.io application.
 
@@ -204,7 +204,7 @@ Examples:
 
 application device type (Check available types with `resin devices supported`)
 
-## <a name="#apps"></a>apps
+## apps
 
 Use this command to list all your applications.
 
@@ -215,7 +215,7 @@ Examples:
 
 	$ resin apps
 
-## <a name="#app-name"></a>app &#60;name&#62;
+## app &#60;name&#62;
 
 Use this command to show detailed information for a single application.
 
@@ -223,7 +223,7 @@ Examples:
 
 	$ resin app MyApp
 
-## <a name="#app-restart-name"></a>app restart &#60;name&#62;
+## app restart &#60;name&#62;
 
 Use this command to restart all devices that belongs to a certain application.
 
@@ -231,7 +231,7 @@ Examples:
 
 	$ resin app restart MyApp
 
-## <a name="#app-rm-name"></a>app rm &#60;name&#62;
+## app rm &#60;name&#62;
 
 Use this command to remove a resin.io application.
 
@@ -251,7 +251,7 @@ confirm non interactively
 
 # Authentication
 
-## <a name="#login"></a>login
+## login
 
 Use this command to login to your resin.io account.
 
@@ -294,7 +294,7 @@ email
 
 password
 
-## <a name="#logout"></a>logout
+## logout
 
 Use this command to logout from your resin.io account.o
 
@@ -302,7 +302,7 @@ Examples:
 
 	$ resin logout
 
-## <a name="#signup"></a>signup
+## signup
 
 Use this command to signup for a resin.io account.
 
@@ -317,7 +317,7 @@ Examples:
 	$ resin whoami
 	johndoe
 
-## <a name="#whoami"></a>whoami
+## whoami
 
 Use this command to find out the current logged in username and email address.
 
@@ -327,7 +327,7 @@ Examples:
 
 # Device
 
-## <a name="#devices"></a>devices
+## devices
 
 Use this command to list all devices that belong to you.
 
@@ -346,7 +346,7 @@ Examples:
 
 application name
 
-## <a name="#device-uuid"></a>device &#60;uuid&#62;
+## device &#60;uuid&#62;
 
 Use this command to show information about a single device.
 
@@ -354,7 +354,7 @@ Examples:
 
 	$ resin device 7cf02a6
 
-## <a name="#devices-supported"></a>devices supported
+## devices supported
 
 Use this command to get the list of all supported devices
 
@@ -362,7 +362,7 @@ Examples:
 
 	$ resin devices supported
 
-## <a name="#device-register-application"></a>device register &#60;application&#62;
+## device register &#60;application&#62;
 
 Use this command to register a device to an application.
 
@@ -384,7 +384,7 @@ custom uuid
 
 custom device key - note that this is only supported on ResinOS 2.0.3+
 
-## <a name="#device-rm-uuid"></a>device rm &#60;uuid&#62;
+## device rm &#60;uuid&#62;
 
 Use this command to remove a device from resin.io.
 
@@ -402,7 +402,7 @@ Examples:
 
 confirm non interactively
 
-## <a name="#device-identify-uuid"></a>device identify &#60;uuid&#62;
+## device identify &#60;uuid&#62;
 
 Use this command to identify a device.
 
@@ -412,7 +412,7 @@ Examples:
 
 	$ resin device identify 23c73a1
 
-## <a name="#device-reboot-uuid"></a>device reboot &#60;uuid&#62;
+## device reboot &#60;uuid&#62;
 
 Use this command to remotely reboot a device
 
@@ -426,7 +426,7 @@ Examples:
 
 force action if the update lock is set
 
-## <a name="#device-shutdown-uuid"></a>device shutdown &#60;uuid&#62;
+## device shutdown &#60;uuid&#62;
 
 Use this command to remotely shutdown a device
 
@@ -440,7 +440,7 @@ Examples:
 
 force action if the update lock is set
 
-## <a name="#device-public-url-enable-uuid"></a>device public-url enable &#60;uuid&#62;
+## device public-url enable &#60;uuid&#62;
 
 Use this command to enable public URL for a device
 
@@ -448,7 +448,7 @@ Examples:
 
 	$ resin device public-url enable 23c73a1
 
-## <a name="#device-public-url-disable-uuid"></a>device public-url disable &#60;uuid&#62;
+## device public-url disable &#60;uuid&#62;
 
 Use this command to disable public URL for a device
 
@@ -456,7 +456,7 @@ Examples:
 
 	$ resin device public-url disable 23c73a1
 
-## <a name="#device-public-url-uuid"></a>device public-url &#60;uuid&#62;
+## device public-url &#60;uuid&#62;
 
 Use this command to get the public URL of a device
 
@@ -464,7 +464,7 @@ Examples:
 
 	$ resin device public-url 23c73a1
 
-## <a name="#device-public-url-status-uuid"></a>device public-url status &#60;uuid&#62;
+## device public-url status &#60;uuid&#62;
 
 Use this command to determine if public URL is enabled for a device
 
@@ -472,7 +472,7 @@ Examples:
 
 	$ resin device public-url status 23c73a1
 
-## <a name="#device-rename-uuid--newname"></a>device rename &#60;uuid&#62; [newName]
+## device rename &#60;uuid&#62; [newName]
 
 Use this command to rename a device.
 
@@ -483,7 +483,7 @@ Examples:
 	$ resin device rename 7cf02a6
 	$ resin device rename 7cf02a6 MyPi
 
-## <a name="#device-move-uuid"></a>device move &#60;uuid&#62;
+## device move &#60;uuid&#62;
 
 Use this command to move a device to another application you own.
 
@@ -500,7 +500,7 @@ Examples:
 
 application name
 
-## <a name="#device-init"></a>device init
+## device init
 
 Use this command to download the OS image of a certain application and write it to an SD Card.
 
@@ -544,7 +544,7 @@ path to the config JSON file, see `resin os build-config`
 
 # Environment Variables
 
-## <a name="#envs"></a>envs
+## envs
 
 Use this command to list all environment variables for
 a particular application or device.
@@ -573,7 +573,7 @@ device uuid
 
 show private environment variables
 
-## <a name="#env-rm-id"></a>env rm &#60;id&#62;
+## env rm &#60;id&#62;
 
 Use this command to remove an environment variable from an application.
 
@@ -600,7 +600,7 @@ confirm non interactively
 
 device
 
-## <a name="#env-add-key--value"></a>env add &#60;key&#62; [value]
+## env add &#60;key&#62; [value]
 
 Use this command to add an enviroment variable to an application.
 
@@ -629,7 +629,7 @@ application name
 
 device uuid
 
-## <a name="#env-rename-id--value"></a>env rename &#60;id&#62; &#60;value&#62;
+## env rename &#60;id&#62; &#60;value&#62;
 
 Use this command to rename an enviroment variable from an application.
 
@@ -648,7 +648,7 @@ device
 
 # Help
 
-## <a name="#help-command"></a>help [command...]
+## help [command...]
 
 Get detailed help for an specific command.
 
@@ -665,13 +665,13 @@ show additional commands
 
 # Information
 
-## <a name="#version"></a>version
+## version
 
 Display the Resin CLI version.
 
 # Keys
 
-## <a name="#keys"></a>keys
+## keys
 
 Use this command to list all your SSH keys.
 
@@ -679,7 +679,7 @@ Examples:
 
 	$ resin keys
 
-## <a name="#key-id"></a>key &#60;id&#62;
+## key &#60;id&#62;
 
 Use this command to show information about a single SSH key.
 
@@ -687,7 +687,7 @@ Examples:
 
 	$ resin key 17
 
-## <a name="#key-rm-id"></a>key rm &#60;id&#62;
+## key rm &#60;id&#62;
 
 Use this command to remove a SSH key from resin.io.
 
@@ -705,7 +705,7 @@ Examples:
 
 confirm non interactively
 
-## <a name="#key-add-name--path"></a>key add &#60;name&#62; [path]
+## key add &#60;name&#62; [path]
 
 Use this command to associate a new SSH key with your account.
 
@@ -719,7 +719,7 @@ Examples:
 
 # Logs
 
-## <a name="#logs-uuid"></a>logs &#60;uuid&#62;
+## logs &#60;uuid&#62;
 
 Use this command to show logs for a specific device.
 
@@ -744,7 +744,7 @@ continuously stream output
 
 # Sync
 
-## <a name="#sync-uuid"></a>sync [uuid]
+## sync [uuid]
 
 Warning: 'resin sync' requires an openssh-compatible client and 'rsync' to
 be correctly installed in your shell environment. For more information (including
@@ -825,7 +825,7 @@ increase verbosity
 
 # SSH
 
-## <a name="#ssh-uuid"></a>ssh [uuid]
+## ssh [uuid]
 
 Warning: 'resin ssh' requires an openssh-compatible client to be correctly
 installed in your shell environment. For more information (including Windows
@@ -862,7 +862,7 @@ don't use the proxy configuration for this connection. Only makes sense if you'v
 
 # Notes
 
-## <a name="#note-note"></a>note &#60;|note&#62;
+## note &#60;|note&#62;
 
 Use this command to set or update a device note.
 
@@ -883,7 +883,7 @@ device uuid
 
 # OS
 
-## <a name="#os-versions-type"></a>os versions &#60;type&#62;
+## os versions &#60;type&#62;
 
 Use this command to show the available resinOS versions for a certain device type.
 Check available types with `resin devices supported`
@@ -892,7 +892,7 @@ Example:
 
 	$ resin os versions raspberrypi3
 
-## <a name="#os-download-type"></a>os download &#60;type&#62;
+## os download &#60;type&#62;
 
 Use this command to download an unconfigured os image for a certain device type.
 Check available types with `resin devices supported`
@@ -927,7 +927,7 @@ or 'default' (excludes pre-releases if at least one stable version is available)
 or 'recommended' (excludes pre-releases, will fail if only pre-release versions are available),
 or 'menu' (will show the interactive menu)
 
-## <a name="#os-build-config-image--device-type"></a>os build-config &#60;image&#62; &#60;device-type&#62;
+## os build-config &#60;image&#62; &#60;device-type&#62;
 
 Use this command to prebuild the OS config once and skip the interactive part of `resin os configure`.
 
@@ -946,7 +946,7 @@ show advanced configuration options
 
 the path to the output JSON file
 
-## <a name="#os-configure-image--uuid--deviceapikey"></a>os configure &#60;image&#62; [uuid] [deviceApiKey]
+## os configure &#60;image&#62; [uuid] [deviceApiKey]
 
 Use this command to configure a previously downloaded operating system image for
 the specific device or for an application generally.
@@ -985,7 +985,7 @@ custom device key - note that this is only supported on ResinOS 2.0.3+
 
 path to the config JSON file, see `resin os build-config`
 
-## <a name="#os-initialize-image"></a>os initialize &#60;image&#62;
+## os initialize &#60;image&#62;
 
 Use this command to initialize a device with previously configured operating system image.
 
@@ -1012,7 +1012,7 @@ the drive to write the image to, like `/dev/sdb` or `/dev/mmcblk0`. Careful with
 
 # Config
 
-## <a name="#config-read"></a>config read
+## config read
 
 Use this command to read the config.json file from the mounted filesystem (e.g. SD card) of a provisioned device"
 
@@ -1031,7 +1031,7 @@ device type (Check available types with `resin devices supported`)
 
 drive
 
-## <a name="#config-write-key--value"></a>config write &#60;key&#62; &#60;value&#62;
+## config write &#60;key&#62; &#60;value&#62;
 
 Use this command to write the config.json file to the mounted filesystem (e.g. SD card) of a provisioned device
 
@@ -1051,7 +1051,7 @@ device type (Check available types with `resin devices supported`)
 
 drive
 
-## <a name="#config-inject-file"></a>config inject &#60;file&#62;
+## config inject &#60;file&#62;
 
 Use this command to inject a config.json file to the mounted filesystem
 (e.g. SD card or mounted resinOS image) of a provisioned device"
@@ -1071,7 +1071,7 @@ device type (Check available types with `resin devices supported`)
 
 drive
 
-## <a name="#config-reconfigure"></a>config reconfigure
+## config reconfigure
 
 Use this command to reconfigure a provisioned device
 
@@ -1095,7 +1095,7 @@ drive
 
 show advanced commands
 
-## <a name="#config-generate"></a>config generate
+## config generate
 
 Use this command to generate a config.json for a device or application.
 
@@ -1148,7 +1148,7 @@ how frequently (in minutes) to poll for application updates
 
 # Preload
 
-## <a name="#preload-image"></a>preload &#60;image&#62;
+## preload &#60;image&#62;
 
 Warning: "resin preload" requires Docker to be correctly installed in
 your shell environment. For more information (including Windows support)
@@ -1206,7 +1206,7 @@ Docker host TLS key file
 
 # Settings
 
-## <a name="#settings"></a>settings
+## settings
 
 Use this command to display detected settings
 
@@ -1216,7 +1216,7 @@ Examples:
 
 # Wizard
 
-## <a name="#quickstart-name"></a>quickstart [name]
+## quickstart [name]
 
 Use this command to run a friendly wizard to get started with resin.io.
 
@@ -1234,7 +1234,7 @@ Examples:
 
 # Local
 
-## <a name="#local-configure-target"></a>local configure &#60;target&#62;
+## local configure &#60;target&#62;
 
 Use this command to configure or reconfigure a resinOS drive or image.
 
@@ -1243,7 +1243,7 @@ Examples:
 	$ resin local configure /dev/sdc
 	$ resin local configure path/to/image.img
 
-## <a name="#local-flash-image"></a>local flash &#60;image&#62;
+## local flash &#60;image&#62;
 
 Use this command to flash a resinOS image to a drive.
 
@@ -1263,7 +1263,7 @@ confirm non-interactively
 
 drive
 
-## <a name="#local-logs-deviceip"></a>local logs [deviceIp]
+## local logs [deviceIp]
 
 
 Examples:
@@ -1284,7 +1284,7 @@ follow log
 
 name of container to get logs from
 
-## <a name="#local-scan"></a>local scan
+## local scan
 
 
 Examples:
@@ -1303,7 +1303,7 @@ Display full info
 
 Scan timeout in seconds
 
-## <a name="#local-ssh-deviceip"></a>local ssh [deviceIp]
+## local ssh [deviceIp]
 
 Warning: 'resin local ssh' requires an openssh-compatible client to be correctly
 installed in your shell environment. For more information (including Windows
@@ -1342,7 +1342,7 @@ name of container to access
 
 ssh port number (default: 22222)
 
-## <a name="#local-push-deviceip"></a>local push [deviceIp]
+## local push [deviceIp]
 
 Warning: 'resin local push' requires an openssh-compatible client and 'rsync' to
 be correctly installed in your shell environment. For more information (including
@@ -1439,7 +1439,7 @@ force a container build and run
 
 environment variable (e.g. --env 'ENV=value'). Multiple --env parameters are supported.
 
-## <a name="#local-stop-deviceip"></a>local stop [deviceIp]
+## local stop [deviceIp]
 
 
 Examples:
@@ -1462,7 +1462,7 @@ name of container to stop
 
 # Deploy
 
-## <a name="#build-source"></a>build [source]
+## build [source]
 
 Use this command to build an image or a complete multicontainer project
 with the provided docker daemon.
@@ -1552,7 +1552,7 @@ Don't use docker layer caching when building
 
 Squash newly built layers into a single new layer
 
-## <a name="#deploy-appname--image"></a>deploy &#60;appName&#62; [image]
+## deploy &#60;appName&#62; [image]
 
 Use this command to deploy an image or a complete multicontainer project
 to an application, optionally building it first.
@@ -1646,7 +1646,7 @@ Squash newly built layers into a single new layer
 
 # Utilities
 
-## <a name="#util-available-drives"></a>util available-drives
+## util available-drives
 
 Use this command to list your machine's drives usable for writing the OS image to.
 Skips the system drives.


### PR DESCRIPTION
More changes after https://github.com/resin-io/resin-cli/pull/813. I've stripped out the actual anchor tags, and updated this to match what the docs seem to want more closely, can you try this as-is @zwalchuk, and see if it works?

It now doesn't work in the docs on github (they don't end up with trailing `-`s for headings like `app <name>`, whereas the docs generation does seem to), but that's not a big problem as long as it works for the docs site. 

Also @zwalchuk can you let me what you do to regenerate the CLI docs pages? This will do as a short-term fix, if it works, but I'd like to dig into it and really work out what's going on here, so we can fix this properly.