### PR TITLE
Update Dockerode to fix local push issue in standalone builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "docker-progress": "^3.0.1",
     "docker-qemu-transpose": "^0.5.1",
     "docker-toolbelt": "^3.1.0",
-    "dockerode": "^2.5.0",
+    "dockerode": "^2.5.5",
     "dockerode-options": "^0.2.1",
     "drivelist": "^5.0.22",
     "ejs": "^2.5.7",


### PR DESCRIPTION
Dockerode patch (https://github.com/apocas/dockerode/pull/445) has now been merged and released, which should let us fix #824 once and for all.

Change-Type: patch