### PR TITLE
fix: Correctly error out on failed remote build

### DIFF
--- a/lib/actions/push.ts
+++ b/lib/actions/push.ts
@@ -156,6 +156,8 @@ export const push: CommandDefinition<
 
 				return remote.startRemoteBuild(args);
 			},
-		).nodeify(done);
+		)
+		.catch(remote.RemoteBuildFailedError, exitWithExpectedError)
+		.nodeify(done);
 	},
 };


### PR DESCRIPTION
The push command was relying on the output from the builder to indicate
the build status, but this isn't helpful for CI. This commit makes the
remote build module respect the `isError` flag which the builder sends
in any errors. Any errors which come from the builder indicate the
release will not be deployed.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>