### PR TITLE
dev: Add fast test npm task, to speed development

### DIFF
--- a/lib/actions/push.ts
+++ b/lib/actions/push.ts
@@ -157,7 +157,7 @@ export const push: CommandDefinition<
 				return remote.startRemoteBuild(args);
 			},
 		)
-		.catch(remote.RemoteBuildFailedError, exitWithExpectedError)
-		.nodeify(done);
+			.catch(remote.RemoteBuildFailedError, exitWithExpectedError)
+			.nodeify(done);
 	},
 };

--- a/lib/actions/push.ts
+++ b/lib/actions/push.ts
@@ -156,6 +156,8 @@ export const push: CommandDefinition<
 
 				return remote.startRemoteBuild(args);
 			},
-		).nodeify(done);
+		)
+		.catch(remote.RemoteBuildFailedError, exitWithExpectedError)
+		.nodeify(done);
 	},
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "release": "npm run build && ts-node --type-check -P automation automation/deploy-bin.ts",
     "pretest": "npm run build",
     "test": "gulp test",
+    "test:fast": "npm run build:fast && gulp test",
     "ci": "npm run test && catch-uncommitted",
     "watch": "gulp watch",
     "prettify": "prettier --write \"{lib,tests,automation,typings}/**/*.ts\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es5",
+		"target": "es6",
 		"outDir": "build",
 		"strict": true,
 		"strictPropertyInitialization": false,


### PR DESCRIPTION
Currently running the tests is painfully slow, this commit adds a task
which will run the bare minimum build, and then the tests, speeding up
the process by an order of magnitude.

I had to repeat `gulp test`, instead of reusing `npm run test`, so that
the pretest task isn't ran too.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>