### PR TITLE
fix: Pin typescript version to stop updating to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "resin-lint": "^1.5.0",
     "rewire": "^3.0.2",
     "ts-node": "^4.0.1",
-    "typescript": "2.8.1"
+    "typescript": "^2.8.1"
   },
   "dependencies": {
     "@resin.io/valid-email": "^0.1.0",


### PR DESCRIPTION
Typescript v3 does not accept the typings on the SDK, so until that is
fixed, pin the typescript version to 2.8.1

Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>