### PR TITLE
Stop Travis deploying to npm (now handled by concourse)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,3 @@ deploy:
       tags: true
       condition: "$TRAVIS_TAG =~ ^v?[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+"
       repo: resin-io/resin-cli
-  - provider: npm
-    email: accounts@resin.io
-    api_key:
-      secure: JoAcGloR8ijX3u8itaF6muCoOY9Xinku9nDkg/N3rzAS8qe8LLkTxty6Zzc28Z7qZiCqmaVKUFUP3wqx1qYp9gH0OuVfQFaTAkjlGpV2Exv9/7DuI4ZxwaWjELJcPD5EIffJRiT0gmvQBWPmDffc4mymoMnVH8UMuDILBDM3pSI=
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: "$TRAVIS_TAG =~ ^v?[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+"
-      repo: resin-io/resin-cli


### PR DESCRIPTION
Fixes #964 
Change-type: patch
Signed-off-by: Tim Perry <tim@resin.io>