### PR TITLE
device: When registering, print the uuid

### DIFF
--- a/lib/actions/device.coffee
+++ b/lib/actions/device.coffee
@@ -164,6 +164,7 @@ exports.register =
 			resin.models.application.get(params.application)
 			options.uuid ? resin.models.device.generateUniqueKey()
 			(application, uuid) ->
+				console.info("Registering to #{application.app_name}: #{uuid}")
 				return resin.models.device.register(application.id, uuid)
 		)
 		.get('uuid')


### PR DESCRIPTION
This restores the behavior from before #911, which is useful from some users.

Closes #966

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablocarranza@gmail.com>