### PR TITLE
Include --emulated in the example resin build parameters

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1554,7 +1554,7 @@ Examples:
 
 	$ resin build
 	$ resin build ./source/
-	$ resin build --deviceType raspberrypi3 --arch armhf
+	$ resin build --deviceType raspberrypi3 --arch armhf --emulated
 	$ resin build --application MyApp ./source/
 	$ resin build --docker '/var/run/docker.sock'
 	$ resin build --dockerHost my.docker.host --dockerPort 2376 --ca ca.pem --key key.pem --cert cert.pem

--- a/lib/actions/build.coffee
+++ b/lib/actions/build.coffee
@@ -66,7 +66,7 @@ module.exports =
 
 			$ resin build
 			$ resin build ./source/
-			$ resin build --deviceType raspberrypi3 --arch armhf
+			$ resin build --deviceType raspberrypi3 --arch armhf --emulated
 			$ resin build --application MyApp ./source/
 			$ resin build --docker '/var/run/docker.sock'
 			$ resin build --dockerHost my.docker.host --dockerPort 2376 --ca ca.pem --key key.pem --cert cert.pem


### PR DESCRIPTION
Nice suggestion from @samothx: https://www.flowdock.com/app/rulemotion/resin-frontend/threads/e1S3z92xsSmiFqFyFil3pRztsHK. This isn't strictly speaking always necessary (e.g. you might be building on an ARM box), but it won't cause problems, and the vast majority of users should be using it in the given example.

Change-type: patch
Signed-off-by: Tim Perry <tim@resin.io>