### PR TITLE
Fix formatting of preload examples

### DIFF
--- a/doc/cli.markdown
+++ b/doc/cli.markdown
@@ -1196,8 +1196,9 @@ Use this command to preload an application to a local disk image (or
 Edison zip archive) with a built release from Resin.io.
 
 Examples:
-  $ resin preload resin.img --app 1234 --commit e1f2592fc6ee949e68756d4f4a48e49bff8d72a0 --splash-image some-image.png
-  $ resin preload resin.img
+
+	$ resin preload resin.img --app 1234 --commit e1f2592fc6ee949e68756d4f4a48e49bff8d72a0 --splash-image some-image.png
+	$ resin preload resin.img
 
 ### Options
 

--- a/lib/actions/preload.coffee
+++ b/lib/actions/preload.coffee
@@ -115,8 +115,9 @@ module.exports =
 		Edison zip archive) with a built release from Resin.io.
 
 		Examples:
-		  $ resin preload resin.img --app 1234 --commit e1f2592fc6ee949e68756d4f4a48e49bff8d72a0 --splash-image some-image.png
-		  $ resin preload resin.img
+
+			$ resin preload resin.img --app 1234 --commit e1f2592fc6ee949e68756d4f4a48e49bff8d72a0 --splash-image some-image.png
+			$ resin preload resin.img
 	'''
 	permission: 'user'
 	primary: true


### PR DESCRIPTION
Based on https://github.com/resin-io/docs/pull/915 from @drjasonharrison-vp-eio. Check the rendered markdown to see the resulting change itself.

Fixes #975 