### PR TITLE
Update sdk references in wizzard.coffee

### DIFF
--- a/lib/actions/wizard.coffee
+++ b/lib/actions/wizard.coffee
@@ -34,7 +34,7 @@ exports.wizard =
 	'''
 	primary: true
 	action: (params, options, done) ->
-		resin = require('resin-sdk-preconfigured')
+		resin = require('resin-sdk').fromSharedOptions()
 		patterns = require('../utils/patterns')
 		{ runCommand } = require('../utils/helpers')
 


### PR DESCRIPTION
Suffers from same problem in windows as `device init` (because it calls it), but otherwise ok I think.