### PR TITLE
Update dockerignore to fix escSL bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@resin.io/valid-email": "^0.1.0",
     "@types/stream-to-promise": "2.2.0",
     "@types/through2": "^2.0.33",
-    "@zeit/dockerignore": "0.0.1",
+    "@zeit/dockerignore": "0.0.3",
     "JSONStream": "^1.0.3",
     "ansi-escapes": "^2.0.0",
     "any-promise": "^1.3.0",


### PR DESCRIPTION
Dockerignore 0.0.1 still contains this bug: https://github.com/zeit/dockerignore/commit/98b02b538858e86e052abb0e6649fa869f710cd5.

Because of this, it always fails on Windows. Upgrading should fix it.

Change-type: patch