### PR TITLE
chore: Add on the fly transpiled bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ If you're having any problems, check our [troubleshooting guide](https://github.
 
 You can also get in touch with us in the resin.io [forums](https://forums.resin.io/).
 
+Development guidelines
+----------------------
+
+After cloning this repository and running `npm install` you can build the CLI using `npm run build`.
+You can then run the generated build using `./bin/resin`.
+In order to ease development:
+* you can build the CLI using the `npm run build:fast` variant which skips some of the build steps or
+* you can use `./bin/resin-dev` which live transpiles the sources of the CLI.
+
+In either case, before opening a PR make sure to also test your changes after doing a full build with `npm run build`.
+
 License
 -------
 

--- a/bin/resin-dev
+++ b/bin/resin-dev
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+// ****************************************************************************
+// THIS IS FOR DEV PERROSES ONLY AND WILL NOT BE PART OF THE PUBLISHED PACKAGE
+// Before opening a PR you should build and test your changes using bin/resin
+// ****************************************************************************
+
+// We boost the threadpool size as ext2fs can deadlock with some
+// operations otherwise, if the pool runs out.
+process.env.UV_THREADPOOL_SIZE = '64';
+
+process.env['TS_NODE_PROJECT'] = require('path').dirname(__dirname);
+require('coffeescript/register');
+require('ts-node/register');
+require('../lib/app');

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "preferGlobal": true,
   "files": [
-    "bin/",
+    "bin/resin",
     "build/",
     "doc/",
     "lib/"


### PR DESCRIPTION
Loved @dfunckt 's suggestion that saves a huge amount of time by not having to build after each change.
Adds an alternative bin file that does not require building the project but loads the source files directly.
Changed the package.json so that the published module doesn't contain the new file and stays the same as before.

Change-type: minor
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>