### PR TITLE
Update package.json for new resin-semver release

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "resin-release": "^1.2.0",
     "resin-sdk": "10.0.0-beta2",
     "resin-sdk-preconfigured": "^6.9.0",
-    "resin-semver": "^1.3.0",
+    "resin-semver": "^1.4.0",
     "resin-settings-client": "^3.6.1",
     "resin-stream-logger": "^0.1.0",
     "resin-sync": "^9.3.3",


### PR DESCRIPTION
This repo is one of the 16 repos identified to use/require a [resin-semver](https://github.com/resin-io-modules/resin-semver) version older than 1.4.0. See also:
* [Trello card](https://trello.com/c/11ZJfEv6/114-update-repos-that-depend-on-resin-semver)
* [Flowdock thread](https://www.flowdock.com/app/rulemotion/namechange/threads/lS-o4xF4qMvf-o2rAtdrqaZEPhs)